### PR TITLE
update test environment

### DIFF
--- a/packages/web-scripts/config/jest.config.js
+++ b/packages/web-scripts/config/jest.config.js
@@ -1,6 +1,5 @@
 module.exports = {
   preset: 'ts-jest/presets/js-with-ts',
-  testEnvironment: 'node',
   globals: {
     'ts-jest': {
       tsConfig: {


### PR DESCRIPTION
**Why**: per some feedback, we are taking the default for `testEnvironment` in Jest for now, which is `jsdom`.