### PR TITLE
fix(web-scripts): drop the `fix` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A collection of base configs and CLI wrappers used to speed up development @ Spo
 
 ### web-scripts CLI
 
-[@spotify/web-scripts](./packages/web-scripts) is a CLI that combines shared configuration for linting, formatting, testing, building, and shipping libraries for Node and the browser. It is opinionated, but allows configuration to avoid lock-in. You can also pick and choose which scripts you use. It is inspired by other tooling bundles like [react-scripts](https://www.npmjs.com/package/react-scripts) and [kcd-scripts](https://www.npmjs.com/package/kcd-scripts).
+[@spotify/web-scripts](./packages/web-scripts) is a CLI that combines shared configuration for building, linting, testing, formatting, and releasing libraries for Node and the browser. It is opinionated, but allows configuration to avoid lock-in. You can also pick and choose which scripts you use. It is inspired by other tooling bundles like [react-scripts](https://www.npmjs.com/package/react-scripts) and [kcd-scripts](https://www.npmjs.com/package/kcd-scripts).
 
 ```bash
 yarn add --dev @spotify/web-scripts husky

--- a/packages/web-scripts/README.md
+++ b/packages/web-scripts/README.md
@@ -2,40 +2,32 @@
 
 ## Description
 
-Build, lint, test, fix, and release your JS/TS library. This CLI tool bundles all the necessary configuration and dependencies so you can focus on the code.
+Build, lint, test, format, and release your JS/TS library. This CLI tool bundles all the necessary configuration and dependencies so you can focus on the code.
 
 ## Usage
 
 ```sh
-yarn add @spotify/web-scripts
+yarn add --dev @spotify/web-scripts husky
 ```
 
-Add the scripts to your package.json:
+Add the scripts and commit hooks to your package.json:
 
 ```json
+{
+  "scripts": {
     "test": "web-scripts test",
     "lint": "web-scripts lint",
-    "fix": "web-scripts fix",
     "build": "web-scripts build",
     "commit": "web-scripts commit",
     "release": "web-scripts release"
-```
-
-Add a husky precommit hook:
-
-```sh
-yarn add --dev husky
-```
-
-And in your package.json:
-
-```json
+  },
   "husky": {
     "hooks": {
       "commit-msg": "web-scripts commitmsg",
       "pre-commit": "web-scripts precommit"
     }
   }
+}
 ```
 
 If you plan to use `web-scripts build` to build ESM, CommonJS, and types for your library with ease, update your package.json to define the locations where those will end up. [Read more about our the build script](#the-build-script).
@@ -48,7 +40,7 @@ If you plan to use `web-scripts build` to build ESM, CommonJS, and types for you
 }
 ```
 
-### Editor support steps:
+### Editor support steps
 
 Add a root tsconfig.json:
 
@@ -93,9 +85,9 @@ web-scripts test --watch
 
 `web-scripts build` runs three parallel calls to the TypeScript compiler.
 
-* One of them transpiles the files as CommonJS and outputs it to the `cjs` directory. Your repo should have `"cjs/index.js"` set as `main` in your package.json. You can turn this off using `--no-cjs` when running build.
-* Another does the exact same thing but only transpiles to [EcmaScript modules](https://github.com/standard-things/esm). This is super helpful if your consuming project is using Babel or TypeScript, and you'll end up avoiding playing games of transpilation telephone along the way. Your repo should have `"esm/index.js"` set as `module` in your package.json if using this. You can turn this off with the `--no-esm` flag when running build.
-* Finally, tsc will be run to output type definitions. Your repo should have the `"types"` directory set as `types` in your package.json if using this. You can turn this off with the `--no-types` flag when running build.
+- One of them transpiles the files as CommonJS and outputs it to the `cjs` directory. Your repo should have `"cjs/index.js"` set as `main` in your package.json. You can turn this off using `--no-cjs` when running build.
+- Another does the exact same thing but only transpiles to [EcmaScript modules](https://github.com/standard-things/esm). This is super helpful if your consuming project is using Babel or TypeScript, and you'll end up avoiding playing games of transpilation telephone along the way. Your repo should have `"esm/index.js"` set as `module` in your package.json if using this. You can turn this off with the `--no-esm` flag when running build.
+- Finally, tsc will be run to output type definitions. Your repo should have the `"types"` directory set as `types` in your package.json if using this. You can turn this off with the `--no-types` flag when running build.
 
 These parallel builds are set up to share resources and work efficiently.
 

--- a/packages/web-scripts/package.json
+++ b/packages/web-scripts/package.json
@@ -2,7 +2,7 @@
   "name": "@spotify/web-scripts",
   "version": "1.0.0",
   "license": "Apache-2.0",
-  "description": "Build, lint, test, and fix your JS/TS library.",
+  "description": "Build, lint, test, format, and release your JS/TS library.",
   "main": "cjs/index.js",
   "module": "esm/index.js",
   "types": "types",

--- a/packages/web-scripts/src/index.ts
+++ b/packages/web-scripts/src/index.ts
@@ -87,34 +87,6 @@ program
   });
 
 program
-  .command('fix')
-  .allowUnknownOption()
-  .description('DEPRECATED - use `web-scripts precommit`')
-  .option(
-    '--prettier-config [path]',
-    'path to prettier config',
-    PRETTIER_CONFIG,
-  )
-  .option('--eslint-config [path]', 'path to eslint config', ESLINT_CONFIG)
-  .action((cmd: Command) => {
-    const {
-      'eslint-config': eslintConfig,
-      'prettier-config': prettierConfig,
-    } = cmd.opts();
-    const t: PrecommitTaskDesc = {
-      name: 'precommit',
-      fix: true,
-      tests: false,
-      jestConfig: JEST_CONFIG,
-      eslintConfig,
-      prettierConfig,
-      restOptions: parseRestOptions(cmd),
-    };
-
-    handleSpawnResult(precommitTask(t));
-  });
-
-program
   .command('precommit')
   .allowUnknownOption()
   .description('Locally validate the repo before committing')

--- a/packages/web-scripts/src/integration.test.ts
+++ b/packages/web-scripts/src/integration.test.ts
@@ -154,7 +154,7 @@ describe('integration tests', () => {
     // this is what is making the tests fail
     // for some reason in docker it can't set the registry to the internal one
     await exec('yarn', { cwd: PKG_ROOT });
-    // Required for the `fix`, `commit`, and `commitmsg` tasks.
+    // Required for the `commit` and `commitmsg` tasks.
     await exec('git init', { cwd: PKG_ROOT });
   }
 


### PR DESCRIPTION
Pardon our dust! `fix` was meant to be dropped before open-sourcing in favor of the clarified and
revamped `precommit`. It's not documented, and would only have been visible if you ran `web-scripts
--help`. In the future this would obviously be a major version, but I'd like to avoid bumping to
2.0.0 three days after open sourcing.