### PR TITLE
ci: drop Node 8 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - '8'
   - '10'
   - '12'
 branches:


### PR DESCRIPTION
I've noticed that our PR builds are a bit slow; the chief reason seems to be that we only get two parallel builds at a time on Travis. I'd like to drop one of the three builds, Node 8, since we discussed that we don't really have to support Node 8 after the EOL, and we generally want to encourage Spotify teams to be on 10 or 12 now. This should cut the PR build time in half for now.