### PR TITLE
Drop support for node v8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - '8'
   - '10'
   - '12'
 branches:

--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -11,6 +11,6 @@
     "access": "public"
   },
   "engines": {
-    "node": "<=8"
+    "node": ">=10"
   }
 }

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -18,6 +18,6 @@
     "access": "public"
   },
   "engines": {
-    "node": "<=8"
+    "node": ">=10"
   }
 }

--- a/packages/eslint-config-typescript/package.json
+++ b/packages/eslint-config-typescript/package.json
@@ -18,6 +18,6 @@
     "access": "public"
   },
   "engines": {
-    "node": "<=8"
+    "node": ">=10"
   }
 }

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -14,6 +14,6 @@
     "access": "public"
   },
   "engines": {
-    "node": "<=8"
+    "node": ">=10"
   }
 }

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -19,6 +19,6 @@
     "access": "public"
   },
   "engines": {
-    "node": "<=8"
+    "node": ">=10"
   }
 }

--- a/packages/web-scripts/package.json
+++ b/packages/web-scripts/package.json
@@ -68,6 +68,6 @@
     "access": "public"
   },
   "engines": {
-    "node": "<=8"
+    "node": ">=10"
   }
 }


### PR DESCRIPTION
- Update `engines` fields
- Remove node 8 from Travis config