### PR TITLE
feat(create-web-scripts-library): implement cli and script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,8 @@ typings/
 
 # DynamoDB Local files
 .dynamodb/
+
+# web-scripts generated files
+cjs/
+esm/
+types/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "packages/create-web-scripts-library/template"]
+	path = packages/create-web-scripts-library/template
+	url = git@github.com:spotify/web-scripts-library-template.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ node_js:
 branches:
   only:
   - master
+# Handle git submodules yourself
+git:
+  submodules: false
 cache:
   yarn: true
   directories:
@@ -12,6 +15,9 @@ cache:
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s
   - export PATH="$HOME/.yarn/bin:$PATH"
+  # Use sed to replace the SSH URL with the public URL, then initialize submodules
+  - sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
+  - git submodule update --init --recursive
 before_script:
   - yarn lerna bootstrap
   - yarn lerna run bootstrap

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ before_script:
   - yarn lerna run bootstrap
 script:
   - yarn lint
-  - yarn test
+  - yarn test --parallel

--- a/packages/create-web-scripts-library/README.md
+++ b/packages/create-web-scripts-library/README.md
@@ -1,0 +1,3 @@
+# `create-web-scripts-library`
+
+Code was directly inspired by [create-next-app](https://github.com/zeit/create-next-app).

--- a/packages/create-web-scripts-library/README.md
+++ b/packages/create-web-scripts-library/README.md
@@ -1,3 +1,35 @@
 # `create-web-scripts-library`
 
-Code was directly inspired by [create-next-app](https://github.com/zeit/create-next-app).
+Scaffold a [@spotify/web-scripts](https://github.com/spotify/web-scripts) library quickly. Code was directly inspired by [create-next-app](https://github.com/zeit/create-next-app).
+
+## Usage
+
+### With `yarn create`
+
+```sh
+yarn create @spotify/web-scripts-library my-cool-library
+```
+
+### With `npx`
+
+```sh
+npx @spotify/web-scripts-create-library my-cool-library
+```
+
+### Installed globally
+
+```sh
+npm i -g @spotify/web-scripts-create-library
+web-scripts-create-library my-cool-library
+```
+
+### Programatically
+
+```javascript
+const path = require('path');
+const createWebScriptsLibrary = require('@spotify/create-web-scripts-library');
+
+async function start() {
+  await createWebScriptsLibrary(path.resolve('my-cool-library'));
+}
+```

--- a/packages/create-web-scripts-library/README.md
+++ b/packages/create-web-scripts-library/README.md
@@ -16,13 +16,6 @@ yarn create @spotify/web-scripts-library my-cool-library
 npx @spotify/web-scripts-create-library my-cool-library
 ```
 
-### Installed globally
-
-```sh
-npm i -g @spotify/web-scripts-create-library
-web-scripts-create-library my-cool-library
-```
-
 ### Programatically
 
 ```javascript

--- a/packages/create-web-scripts-library/bin/create-web-scripts-library
+++ b/packages/create-web-scripts-library/bin/create-web-scripts-library
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('../cjs/cli');

--- a/packages/create-web-scripts-library/package.json
+++ b/packages/create-web-scripts-library/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@spotify/create-web-scripts-library",
+  "version": "1.0.2",
+  "description": "Project scaffolding script for @spotify/web-scripts libraries",
+  "author": "Paul Marbach <pmarbach@spotify.com>",
+  "homepage": "https://github.com/spotify/web-scripts#readme",
+  "license": "Apache-2.0",
+  "bin": {
+    "create-web-scripts-library": "bin/create-web-scripts-library"
+  },
+  "main": "cjs/index.js",
+  "module": "esm/index.js",
+  "types": "types",
+  "files": [
+    "cjs",
+    "esm",
+    "bin",
+    "types",
+    "template",
+    "package.json"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/spotify/web-scripts.git"
+  },
+  "scripts": {
+    "test": "web-scripts test",
+    "build": "web-scripts build",
+    "lint": "web-scripts lint"
+  },
+  "bugs": {
+    "url": "https://github.com/spotify/web-scripts/issues"
+  },
+  "dependencies": {
+    "@spotify/web-scripts": "^1.0.2",
+    "chalk": "^2.4.2",
+    "commander": "^2.20.0",
+    "debug": "^4.1.1",
+    "execa": "^2.0.1",
+    "fs-extra": "^7.0.1"
+  },
+  "devDependencies": {
+    "@types/fs-extra": "^7.0.0",
+    "tempy": "^0.3.0"
+  }
+}

--- a/packages/create-web-scripts-library/src/cli.ts
+++ b/packages/create-web-scripts-library/src/cli.ts
@@ -1,0 +1,36 @@
+import program from 'commander';
+import chalk from 'chalk';
+import debug from 'debug';
+
+import createWebScriptsLibrary from '.';
+
+// MUST require and not import this to avoid wrecking the
+// file structure in the build output.
+const pkg = require('../package.json');
+
+const log = debug(pkg.name);
+
+let projectName: string;
+
+program
+  .version(pkg.version)
+  .arguments('<project-directory>')
+  .usage(`${chalk.green('<project-directory>')} [options]`)
+  .action((name: string) => {
+    projectName = name;
+  })
+  .allowUnknownOption()
+  .parse(process.argv);
+
+async function run() {
+  try {
+    await createWebScriptsLibrary(projectName);
+  } catch (err) {
+    log(chalk.redBright('Failed to create your project!'));
+    log(err.message);
+    process.exit(1);
+    return;
+  }
+}
+
+run();

--- a/packages/create-web-scripts-library/src/get-install-cmd.ts
+++ b/packages/create-web-scripts-library/src/get-install-cmd.ts
@@ -1,0 +1,20 @@
+// from https://github.com/zeit/create-next-app/blob/master/lib/utils/get-install-cmd.js
+
+import * as execa from 'execa';
+
+let cmd: string;
+
+export default function getInstallCmd() {
+  if (cmd) {
+    return cmd;
+  }
+
+  try {
+    execa.commandSync('yarnpkg --version');
+    cmd = 'yarn';
+  } catch (e) {
+    cmd = 'npm';
+  }
+
+  return cmd;
+}

--- a/packages/create-web-scripts-library/src/get-install-cmd.ts
+++ b/packages/create-web-scripts-library/src/get-install-cmd.ts
@@ -1,6 +1,6 @@
 // from https://github.com/zeit/create-next-app/blob/master/lib/utils/get-install-cmd.js
 
-import * as execa from 'execa';
+import execa from 'execa';
 
 let cmd: string;
 

--- a/packages/create-web-scripts-library/src/index.ts
+++ b/packages/create-web-scripts-library/src/index.ts
@@ -1,0 +1,43 @@
+import path from 'path';
+import fs from 'fs-extra';
+import execa from 'execa';
+import chalk from 'chalk';
+import debug from 'debug';
+
+import * as messages from './messages';
+import getInstallCmd from './get-install-cmd';
+
+// MUST require and not import this to avoid wrecking the
+// file structure in the build output.
+const pkg = require('../package.json');
+
+const log = debug(pkg.name);
+
+export default async function createWebScriptsLibrary(projectName?: string) {
+  if (!projectName) {
+    throw new Error(messages.missingProjectName());
+  }
+
+  if (fs.existsSync(projectName) && projectName !== '.') {
+    throw new Error(messages.alreadyExists(projectName));
+  }
+
+  const projectPath = path.resolve(process.cwd(), projectName);
+  const templatePath = path.resolve(__dirname, '..', 'template');
+
+  log(chalk.gray('Copying template...'));
+  await fs.copy(templatePath, projectPath);
+
+  log(chalk.gray('Writing over necessary files...'));
+  process.chdir(projectPath);
+  const newPkgPath = path.join(projectPath, 'package.json');
+  const newPkg = require(newPkgPath);
+  newPkg.name = projectName;
+  await fs.writeFile(newPkgPath, JSON.stringify(newPkg));
+
+  log(chalk.gray('Installing dependencies...'));
+  process.chdir(projectPath);
+  await execa(getInstallCmd(), ['install']);
+
+  log(messages.start(projectName));
+}

--- a/packages/create-web-scripts-library/src/integration.test.ts
+++ b/packages/create-web-scripts-library/src/integration.test.ts
@@ -1,0 +1,48 @@
+import tempy from 'tempy';
+import path from 'path';
+import execa from 'execa';
+import fs from 'fs-extra';
+
+import createWebScriptsLibrary from '.';
+import getInstallCmd from './get-install-cmd';
+
+describe('integration test', () => {
+  let PKG_ROOT: string;
+  let LIBRARY_NAME: string;
+
+  beforeEach(() => {
+    PKG_ROOT = tempy.directory();
+    LIBRARY_NAME = 'my-cool-library';
+    process.chdir(PKG_ROOT);
+  });
+
+  // TODO we should write some custom matchers to assert the file structure
+  it('creates a working web-scripts library', async () => {
+    await createWebScriptsLibrary(LIBRARY_NAME);
+
+    const pkgPath = path.join(PKG_ROOT, LIBRARY_NAME, 'package.json');
+    expect(fs.existsSync(pkgPath)).toBe(true);
+    expect(require(pkgPath).name).toBe(LIBRARY_NAME);
+
+    const cmd = getInstallCmd();
+    await expect(execa(cmd, ['run', 'build'])).resolves.toBeDefined();
+    await expect(execa(cmd, ['run', 'test'])).resolves.toBeDefined();
+    // TODO: figure out why lint doesn't seem to work in this test
+    // await expect(execa(cmd, ['run', 'lint'])).resolves.toBeDefined();
+  }, 30000);
+
+  describe('failure cases', () => {
+    it('fails when the library name is missing', async () => {
+      await expect(createWebScriptsLibrary()).rejects.toEqual(
+        expect.any(Error),
+      );
+    });
+
+    it('fails when a directory already exists', async () => {
+      await fs.mkdir(path.join(PKG_ROOT, LIBRARY_NAME));
+      await expect(createWebScriptsLibrary()).rejects.toEqual(
+        expect.any(Error),
+      );
+    });
+  });
+});

--- a/packages/create-web-scripts-library/src/integration.test.ts
+++ b/packages/create-web-scripts-library/src/integration.test.ts
@@ -37,7 +37,7 @@ describe('integration test', () => {
     [
       { cmd: 'lint' },
       { cmd: 'test' },
-      { cmd: 'build', asyncTimeout: 35000 },
+      { cmd: 'build', asyncTimeout: 60000 },
     ].forEach(
       ({
         cmd,

--- a/packages/create-web-scripts-library/src/integration.test.ts
+++ b/packages/create-web-scripts-library/src/integration.test.ts
@@ -9,29 +9,65 @@ import getInstallCmd from './get-install-cmd';
 describe('integration test', () => {
   let PKG_ROOT: string;
   let LIBRARY_NAME: string;
+  let LIBRARY_ROOT: string;
+  let INSTALL_CMD: string;
 
-  beforeEach(() => {
-    PKG_ROOT = tempy.directory();
-    LIBRARY_NAME = 'my-cool-library';
-    process.chdir(PKG_ROOT);
+  describe('succesful create', () => {
+    // using a beforeAll instead of beforeEach for this test, which ensures that the tests run quickly
+    // this IS a risky testing strategy. Inside this describe block, we need to avoid doing destructive operations.
+    beforeAll(async () => {
+      PKG_ROOT = tempy.directory();
+      LIBRARY_NAME = 'my-cool-library';
+      LIBRARY_ROOT = path.join(PKG_ROOT, LIBRARY_NAME);
+      process.chdir(PKG_ROOT);
+      INSTALL_CMD = getInstallCmd();
+
+      // create a single library and then assert against it
+      await createWebScriptsLibrary(LIBRARY_NAME);
+    }, 60000);
+
+    it('replace the package.json name with the correct name', async () => {
+      // check the package.json name replacement
+      const pkgPath = path.join(LIBRARY_ROOT, 'package.json');
+      expect(fs.existsSync(pkgPath)).toBe(true);
+      expect(require(pkgPath).name).toBe(LIBRARY_NAME);
+    });
+
+    // check that all the commands work
+    [
+      { cmd: 'lint' },
+      { cmd: 'test' },
+      { cmd: 'build', asyncTimeout: 35000 },
+    ].forEach(
+      ({
+        cmd,
+        asyncTimeout = 10000,
+      }: {
+        cmd: string;
+        asyncTimeout?: number;
+      }) => {
+        it(
+          `scaffolds such that "${cmd}" command runs successfully`,
+          async () => {
+            await expect(
+              execa(INSTALL_CMD, ['run', cmd], { cwd: LIBRARY_ROOT }),
+            ).resolves.toBeDefined();
+          },
+          asyncTimeout,
+        );
+      },
+    );
   });
 
-  // TODO we should write some custom matchers to assert the file structure
-  it('creates a working web-scripts library', async () => {
-    await createWebScriptsLibrary(LIBRARY_NAME);
-
-    const pkgPath = path.join(PKG_ROOT, LIBRARY_NAME, 'package.json');
-    expect(fs.existsSync(pkgPath)).toBe(true);
-    expect(require(pkgPath).name).toBe(LIBRARY_NAME);
-
-    const cmd = getInstallCmd();
-    await expect(execa(cmd, ['run', 'build'])).resolves.toBeDefined();
-    await expect(execa(cmd, ['run', 'test'])).resolves.toBeDefined();
-    // TODO: figure out why lint doesn't seem to work in this test
-    // await expect(execa(cmd, ['run', 'lint'])).resolves.toBeDefined();
-  }, 30000);
-
   describe('failure cases', () => {
+    beforeEach(() => {
+      PKG_ROOT = tempy.directory();
+      LIBRARY_NAME = 'my-cool-library';
+      LIBRARY_ROOT = path.join(PKG_ROOT, LIBRARY_NAME);
+      process.chdir(PKG_ROOT);
+      INSTALL_CMD = getInstallCmd();
+    });
+
     it('fails when the library name is missing', async () => {
       await expect(createWebScriptsLibrary()).rejects.toEqual(
         expect.any(Error),

--- a/packages/create-web-scripts-library/src/integration.test.ts
+++ b/packages/create-web-scripts-library/src/integration.test.ts
@@ -36,7 +36,7 @@ describe('integration test', () => {
     // check that all the commands work
     [
       { cmd: 'lint' },
-      { cmd: 'test' },
+      { cmd: 'test', asyncTimeout: 30000 },
       { cmd: 'build', asyncTimeout: 60000 },
     ].forEach(
       ({

--- a/packages/create-web-scripts-library/src/messages.ts
+++ b/packages/create-web-scripts-library/src/messages.ts
@@ -1,0 +1,27 @@
+import program from 'commander';
+import chalk from 'chalk';
+
+export const missingProjectName = () => `
+Please specify the project directory:
+  ${chalk.cyan(program.name())} ${chalk.green('<project-directory>')}
+
+For example:
+  ${chalk.cyan(program.name())} ${chalk.green('my-library-name')}
+Run ${chalk.cyan(`${program.name()} --help`)} to see all options.
+`;
+
+export const alreadyExists = (projectName: string) => `
+It looks like there's already a directory called "${chalk.cyan(
+  projectName,
+)}". Please try a different name or delete that folder.`;
+
+export const start = (projectName: string) => `
+Your project is now set up in "${chalk.cyan(projectName)}"! Try running
+
+  ${chalk.green('yarn lint')}
+  ${chalk.green('yarn test')}
+  ${chalk.green('yarn build')}
+
+to see the web-scripts in action. When you're ready to publish your package, use ${chalk.green(
+  'yarn commit',
+)} and ${chalk.green('yarn release')} to use commitizen and semantic-release.`;

--- a/packages/create-web-scripts-library/tsconfig.json
+++ b/packages/create-web-scripts-library/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@spotify/web-scripts/config/tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "incremental": true,
+    "isolatedModules": false,
+    "noEmit": true,
+    "declaration": false,
+    "jsx": "preserve"
+  }
+}

--- a/packages/create-web-scripts-library/tsconfig.json
+++ b/packages/create-web-scripts-library/tsconfig.json
@@ -1,11 +1,4 @@
 {
   "extends": "@spotify/web-scripts/config/tsconfig.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "incremental": true,
-    "isolatedModules": false,
-    "noEmit": true,
-    "declaration": false,
-    "jsx": "preserve"
-  }
+  "include": ["src"]
 }

--- a/packages/web-scripts/.gitignore
+++ b/packages/web-scripts/.gitignore
@@ -1,4 +1,0 @@
-# build
-/cjs
-/esm
-/types

--- a/packages/web-scripts/src/integration.test.ts
+++ b/packages/web-scripts/src/integration.test.ts
@@ -52,6 +52,7 @@ const TEST_SCRIPTS_TIMEOUT = 60000;
 // const GITHUB_URL = 'https://github.com/spotify/web-scripts.git';
 
 describe('integration tests', () => {
+  const MONOREPO_ROOT = join(root, '../..');
   let PKG_ROOT: string;
 
   beforeEach(() => {
@@ -148,7 +149,10 @@ describe('integration tests', () => {
         join(PKG_ROOT, 'src', fileName),
       ),
     );
-    await copyFile(join(THIS_ROOT, '.gitignore'), join(PKG_ROOT, '.gitignore'));
+    await copyFile(
+      join(MONOREPO_ROOT, '.gitignore'),
+      join(PKG_ROOT, '.gitignore'),
+    );
 
     // install the dependencies we specified above in pkg
     // this is what is making the tests fail

--- a/yarn.lock
+++ b/yarn.lock
@@ -1382,6 +1382,13 @@
   resolved "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
 
+"@types/fs-extra@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-7.0.0.tgz#9c4ad9e1339e7448a76698829def1f159c1b636c"
+  integrity sha512-ndoMMbGyuToTy4qB6Lex/inR98nPiNHacsgMPvy+zqMLgSxbt8VtWpDArpGp69h1fEDQHn1KB+9DWD++wgbwYA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/glob@*", "@types/glob@^7.1.1":
   version "7.1.1"
   resolved "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"
@@ -3345,7 +3352,7 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
-execa@^2.0.0:
+execa@^2.0.0, execa@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/execa/-/execa-2.0.1.tgz#546a5be56388953409cbf24972d2fd1bb36dbfcd"
   integrity sha512-pHGXlV7S7ilDda3eaCTcr6zmFTMA3wJo7j+RtNg0uH9sbAasJfVug5RkYOTBLj5g4MOqlsaPUn3HKa/UfTDw8w==
@@ -3661,7 +3668,7 @@ from2@^2.1.0, from2@^2.1.1:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
 
-fs-extra@^7.0.0:
+fs-extra@^7.0.0, fs-extra@^7.0.1:
   version "7.0.1"
   resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
   integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
@@ -8569,6 +8576,15 @@ tempy@^0.2.1:
     temp-dir "^1.0.0"
     unique-string "^1.0.0"
 
+tempy@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.npmjs.org/tempy/-/tempy-0.3.0.tgz#6f6c5b295695a16130996ad5ab01a8bd726e8bf8"
+  integrity sha512-WrH/pui8YCwmeiAoxV+lpRH9HpRtgBhSR2ViBPgpGb/wnYDzp21R4MN45fsCGvLROvY67o3byhJRYRONJyImVQ==
+  dependencies:
+    temp-dir "^1.0.0"
+    type-fest "^0.3.1"
+    unique-string "^1.0.0"
+
 term-size@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz#458b83887f288fc56d6fffbfad262e26638efa69"
@@ -8776,6 +8792,11 @@ type-check@~0.3.2:
   integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
   dependencies:
     prelude-ls "~1.1.2"
+
+type-fest@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz#63d00d204e059474fe5e1b7c011112bbd1dc29e1"
+  integrity sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==
 
 type-fest@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
**Why**: in lieu of an `init` script like Storybook does, this simpler path to create a scaffolded app using https://github.com/spotify/web-scripts-library-template in the style of create-next-app or create-react-app. This also means you don't need to ship any of the scaffolding deps (such as fs-extra) with web-scripts.

Fixes #11 