### PR TITLE
 fix(create-web-scripts-library): move web-scripts to devDependency 

### DIFF
--- a/packages/create-web-scripts-library/package.json
+++ b/packages/create-web-scripts-library/package.json
@@ -42,5 +42,11 @@
   "devDependencies": {
     "@types/fs-extra": "^7.0.0",
     "tempy": "^0.3.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=10"
   }
 }

--- a/packages/create-web-scripts-library/package.json
+++ b/packages/create-web-scripts-library/package.json
@@ -33,13 +33,13 @@
     "url": "https://github.com/spotify/web-scripts/issues"
   },
   "dependencies": {
-    "@spotify/web-scripts": "^1.1.0",
     "chalk": "^2.4.2",
     "commander": "^2.20.0",
     "execa": "^2.0.1",
     "fs-extra": "^7.0.1"
   },
   "devDependencies": {
+    "@spotify/web-scripts": "^1.1.0",
     "@types/fs-extra": "^7.0.0",
     "tempy": "^0.3.0"
   },


### PR DESCRIPTION
**Why**: noticed when using this through things like `npx` and `yarn create` install all of the web-scripts dependencies, which it definitely doesn't need to do.