### PR TITLE
fix(web-scripts): allow all test options to be configured

### DIFF
--- a/packages/web-scripts/config/jest.config.js
+++ b/packages/web-scripts/config/jest.config.js
@@ -1,4 +1,9 @@
+const path = require('path');
+
 module.exports = {
+  rootDir: path.join(process.cwd(), 'src'),
+  coverageDirectory: path.join(process.cwd(), 'coverage'),
+  collectCoverageFrom: ['**/*.{js,jsx,ts,tsx}'],
   preset: 'ts-jest/presets/js-with-ts',
   globals: {
     'ts-jest': {

--- a/packages/web-scripts/config/lint-staged.config.js
+++ b/packages/web-scripts/config/lint-staged.config.js
@@ -1,5 +1,4 @@
 const { PRETTIER_CONFIG, ESLINT_CONFIG, JEST_CONFIG } = require('../cjs/Paths');
-const path = require('path');
 
 const fix = process.env.WEB_SCRIPTS_SHOULD_FIX === 'true';
 const tests = process.env.WEB_SCRIPTS_RUN_TESTS === 'true';
@@ -8,10 +7,7 @@ const prettierConfig =
   process.env.WEB_SCRIPTS_PRETTIER_CONFIG || PRETTIER_CONFIG;
 const eslintConfig = process.env.WEB_SCRIPTS_ESLINT_CONFIG || ESLINT_CONFIG;
 
-const testRelatedChanges = `jest --config ${jestConfig} --rootDir ${path.join(
-  process.cwd(),
-  'src',
-)} --bail --findRelatedTests`;
+const testRelatedChanges = `jest --config ${jestConfig} --bail --findRelatedTests`;
 
 const lintRelatedChanges = `eslint ${
   fix ? '--fix' : ''

--- a/packages/web-scripts/src/Tasks/TestTask.ts
+++ b/packages/web-scripts/src/Tasks/TestTask.ts
@@ -1,26 +1,17 @@
 import { TestTaskDesc } from '../SharedTypes';
 import { default as spawn } from 'cross-spawn';
-import { join } from 'path';
 import { default as Debug } from 'debug';
 import { SpawnSyncReturns } from 'child_process';
 const dbg = Debug('web-scripts:test'); // eslint-disable-line new-cap
 
 export function testTask(task: TestTaskDesc): SpawnSyncReturns<Buffer> {
-  const root = join(process.cwd(), 'src');
   // `coverageDirectory` is necessary because the root is `src`
-  const coverageDirectory = join(process.cwd(), 'coverage');
   const cmd = 'npx';
   const args = [
     '--no-install',
     'jest',
     '--config',
     task.config,
-    '--rootDir',
-    root,
-    '--coverageDirectory',
-    coverageDirectory,
-    '--collectCoverageFrom',
-    '**/*.{js,jsx,ts,tsx}',
     ...task.restOptions,
   ];
   dbg('npx args %o', args);


### PR DESCRIPTION
**Why**: rootDir, coverageDirectory, and collectCoverageFrom were all configured by providing
non-overrideable values in the CLI invocation arguments. This moves those values into the base
config, which we encourage people to spread over for their custom configuration.

fix #19