### PR TITLE
feat(eslint-config-base): Add rule for disallowing useless constructors

### DIFF
--- a/packages/eslint-config-base/es6.js
+++ b/packages/eslint-config-base/es6.js
@@ -24,6 +24,8 @@ module.exports = {
     'no-const-assign': 2,
     // disallow to use this/super before super() calling in constructors.
     'no-this-before-super': 0,
+    // disallow empty constructors and constructors that only delegate into the parent class.
+    'no-useless-constructor': 2,
     // require let or const instead of var
     'no-var': 2,
     // require method and property shorthand syntax for object literals


### PR DESCRIPTION
BREAKING CHANGE: Adding a lint rule which doesn't have a fix, which means that upgrading could break builds due to the new rule.

Rule is here: https://eslint.org/docs/rules/no-useless-constructor
Some brief discussion about a fix here, which I might have a go at implementing: https://github.com/eslint/eslint/issues/11693