### PR TITLE
fix(web-scripts): only allow Jest globals in test files

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -30,12 +30,20 @@ module.exports = {
     hasTypescript ? 'prettier/@typescript-eslint' : null,
   ].filter(s => !!s),
   parser: '@typescript-eslint/parser',
-  env: {
-    jest: true,
-  },
   parserOptions: {
     ecmaVersion: 2018,
     sourceType: 'module',
   },
+  overrides: [
+    {
+      files: [
+        '**/__@(tests|mocks)__/**/*.[jt]s?(x)',
+        '**/*.@(spec|test).[jt]s?(x)',
+      ],
+      env: {
+        jest: true,
+      },
+    },
+  ],
   settings,
 };


### PR DESCRIPTION
Previously we set `env: jest` globally in eslintrc.js, which means that Jest globals such as
`describe` are allowed by eslint in any file. This commit moves this configuration into an override
with the pattern set to the default Jest test match pattern
(https://jestjs.io/docs/en/configuration#testmatch-array-string). This means that we'll correctly
generate linting errors if these globals are referenced outside tests.

Debatable whether this is a fix or a breaking change:
* It has the potential to reveal problems with non-test scripts referencing jest globals
* It will also mean that people need to override this config if they're using a different value for testMatch in their jest config.