### PR TITLE
fix: Add repostiory field to package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@spotify/web-scripts-monorepo",
   "private": true,
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/spotify/web-scripts.git"
+  },
   "scripts": {
     "test": "lerna run test --stream",
     "build": "lerna run build --stream",

--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -7,6 +7,10 @@
   "peerDependencies": {
     "eslint": ">=5.x"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/spotify/web-scripts.git"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -3,6 +3,10 @@
   "version": "1.1.0",
   "license": "Apache-2.0",
   "description": "Spotify's ESLint config for React projects",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/spotify/web-scripts.git"
+  },
   "main": "index.js",
   "devDependencies": {
     "eslint": "^5.16.0",

--- a/packages/eslint-config-typescript/package.json
+++ b/packages/eslint-config-typescript/package.json
@@ -9,6 +9,10 @@
     "@typescript-eslint/parser": "^1.11.0",
     "eslint": "^5.16.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/spotify/web-scripts.git"
+  },
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": ">=1.5 <2",
     "@typescript-eslint/parser": ">=1.5 <2",

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -3,6 +3,10 @@
   "version": "1.1.0",
   "license": "Apache-2.0",
   "description": "Spotify's base Prettier config",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/spotify/web-scripts.git"
+  },
   "main": "index.js",
   "devDependencies": {
     "prettier": "^1.18.2"

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -3,6 +3,10 @@
   "version": "1.1.0",
   "license": "Apache-2.0",
   "description": "Common tsconfigs to be used as your base configurations",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/spotify/web-scripts.git"
+  },
   "files": [
     "tsconfig.*.json"
   ],

--- a/packages/web-scripts/package.json
+++ b/packages/web-scripts/package.json
@@ -3,6 +3,10 @@
   "version": "1.1.0",
   "license": "Apache-2.0",
   "description": "Build, lint, test, format, and release your JS/TS library.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/spotify/web-scripts.git"
+  },
   "main": "cjs/index.js",
   "module": "esm/index.js",
   "types": "types",


### PR DESCRIPTION
Adding repository links in `package.json` will make this repo more discoverable (since it adds a link at  https://www.npmjs.com/package/@spotify/web-scripts). Marked as a fix to trigger a publish.