### PR TITLE
docs: Update README to have the package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# web-scripts
+# @spotify/web-scripts
 
 [![Build Status](https://travis-ci.com/spotify/web-scripts.svg?branch=master)](https://travis-ci.com/spotify/web-scripts)
 


### PR DESCRIPTION
Reduce ambiguity between `@spotify/web-scripts` and just `web-scripts` (which also exists in npm registry)