### PR TITLE
fix(eslint-config-react): Update eslint-config-react README

### DIFF
--- a/packages/eslint-config-react/README.md
+++ b/packages/eslint-config-react/README.md
@@ -5,7 +5,7 @@ Spotify's ESLint config for react.
 ## Installation
 
 ```sh
-yarn add --dev @spotify/eslint-config-react eslint eslint-plugin-react
+yarn add --dev @spotify/eslint-config-react eslint eslint-plugin-react eslint-plugin-jsx-a11y
 ```
 
 ## Usage


### PR DESCRIPTION
Hey there 👋! 

Saw that the `eslint-plugin-jsx-a11y` is required for the `eslint-config-react` web script so updated the README docs accordingly.