### PR TITLE
feat(web-scripts): add typechecking to lint task

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "lerna run test --stream",
     "build": "lerna run build --stream",
-    "lint": "web-scripts lint --ignore-path .gitignore",
+    "lint": "lerna run lint --stream",
     "commit": "web-scripts commit",
     "bootstrap": "lerna bootstrap --use-workspaces"
   },

--- a/packages/web-scripts/src/SharedTypes.ts
+++ b/packages/web-scripts/src/SharedTypes.ts
@@ -28,6 +28,7 @@ export type TestTaskDesc = {
 export type LintTaskDesc = {
   name: 'lint';
   config: string;
+  typecheck: boolean;
 } & TaskDesc;
 
 export type CommitTaskDesc = {

--- a/packages/web-scripts/src/index.ts
+++ b/packages/web-scripts/src/index.ts
@@ -73,17 +73,19 @@ program
 program
   .command('lint')
   .allowUnknownOption()
-  .description('Run eslint')
+  .description('Run ESLint and TypeScript to statically analyze your code')
   .option('--config [path]', 'path to ESLint config', ESLINT_CONFIG)
+  .option('--typecheck', 'do not run a TypeScript type check')
   .action((cmd: Command) => {
-    const { config } = cmd.opts();
+    const { typecheck, config } = cmd.opts();
     const t: LintTaskDesc = {
       name: 'lint',
       config,
+      typecheck,
       restOptions: parseRestOptions(cmd),
     };
 
-    handleSpawnResult(lintTask(t));
+    handlePromiseResult(lintTask(t));
   });
 
 program

--- a/packages/web-scripts/src/index.ts
+++ b/packages/web-scripts/src/index.ts
@@ -75,7 +75,7 @@ program
   .allowUnknownOption()
   .description('Run ESLint and TypeScript to statically analyze your code')
   .option('--config [path]', 'path to ESLint config', ESLINT_CONFIG)
-  .option('--typecheck', 'do not run a TypeScript type check')
+  .option('--typecheck', 'run a TypeScript type check')
   .action((cmd: Command) => {
     const { typecheck, config } = cmd.opts();
     const t: LintTaskDesc = {

--- a/packages/web-scripts/src/integration.test.ts
+++ b/packages/web-scripts/src/integration.test.ts
@@ -78,7 +78,7 @@ describe('integration tests', () => {
 
     test(
       'Full integration test',
-      async () => await testScripts(),
+      async () => await testScripts([], ['--typecheck']),
       TEST_SCRIPTS_TIMEOUT,
     );
   });
@@ -163,7 +163,10 @@ describe('integration tests', () => {
     await exec('git init', { cwd: PKG_ROOT });
   }
 
-  async function testScripts(buildArgs: string[] = []) {
+  async function testScripts(
+    buildArgs: string[] = [],
+    lintArgs: string[] = [],
+  ) {
     try {
       rimraf.sync(join(PKG_ROOT, 'cjs'));
       expect(existsSync(join(PKG_ROOT, 'cjs/index.js'))).toBe(false);
@@ -171,7 +174,7 @@ describe('integration tests', () => {
       expect(existsSync(join(PKG_ROOT, 'cjs/index.js'))).toBe(true);
 
       await exec('yarn test', { cwd: PKG_ROOT });
-      await exec('yarn lint', { cwd: PKG_ROOT });
+      await exec(['yarn lint', ...lintArgs].join(' '), { cwd: PKG_ROOT });
     } catch (e) {
       // We are not capturing and printing stdout above, where TSC prints its errors. This makes sure it's printed.
       console.log(e.stdout); // eslint-disable-line no-console

--- a/yarn.lock
+++ b/yarn.lock
@@ -5792,9 +5792,9 @@ lodash.without@~4.4.0:
   integrity sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=
 
 lodash@4.17.11, lodash@>=4.17.12, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1:
-  version "4.17.14"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
-  integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
+  version "4.17.15"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 log-symbols@^1.0.2:
   version "1.0.2"
@@ -6159,7 +6159,7 @@ mississippi@^3.0.0:
 
 mixin-deep@>=1.3.2, mixin-deep@^1.2.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-2.0.1.tgz#9a6946bef4a368401b784970ae3caaaa6bab02fa"
+  resolved "https://registry.npmjs.org/mixin-deep/-/mixin-deep-2.0.1.tgz#9a6946bef4a368401b784970ae3caaaa6bab02fa"
   integrity sha512-imbHQNRglyaplMmjBLL3V5R6Bfq5oM+ivds3SKgc6oRtzErEnBUUc5No11Z2pilkUvl42gJvi285xTNswcKCMA==
 
 mkdirp@0.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
@@ -7963,7 +7963,7 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
 
 set-value@>=3.0.1, set-value@^0.4.3, set-value@^2.0.0:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/set-value/-/set-value-3.0.1.tgz#52c82af7653ba69eb1db92e81f5cdb32739b9e95"
+  resolved "https://registry.npmjs.org/set-value/-/set-value-3.0.1.tgz#52c82af7653ba69eb1db92e81f5cdb32739b9e95"
   integrity sha512-w6n3GUPYAWQj4ZyHWzD7K2FnFXHx9OTwJYbWg+6nXjG8sCLfs9DGv+KlqglKIIJx+ks7MlFuwFW2RBPb+8V+xg==
   dependencies:
     is-plain-object "^2.0.4"


### PR DESCRIPTION
We've been talking about making a few changes to the base behavior of `web-scripts lint`:

1. We would like there to be a build artifact output by ESLint by default. This would help us to assess whether builds ran static analysis without having to do invasive checks.
2. We would like to run typecheks by default as part of linting. This will help us move to using Babel to build if we decide that makes sense eventually; it will also help us avoid needing to run `web-scripts build` to properly test a project, which is a bit unintuitive at the moment.

This PR:
- **adds a type check by default to `web-scripts lint`.** You can turn it off by using `--no-typecheck`.
- **adds a parallel ESLint run which outputs Checkstyle**. Since you can't use two formatters for ESLint, and ESLint forces you to write files yourself using stdout, this seems to be the only option. You can turn this off with `--no-output`.