### PR TITLE
ci: publish using CI with Github Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: Publish
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: textbook/git-checkout-submodule-action@master
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12.0
+    - name: yarn install
+      run: yarn
+    - name: lint
+      run: yarn lint
+    - name: test
+      run: yarn test
+    - name: build
+      run: yarn build
+    - name: release
+      run: yarn release
+      env:
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "lerna run build --stream",
     "lint": "web-scripts lint --ignore-path .gitignore",
     "commit": "web-scripts commit",
-    "bootstrap": "lerna bootstrap --use-workspaces"
+    "bootstrap": "lerna bootstrap --use-workspaces",
+    "release": "./release.sh"
   },
   "workspaces": [
     "packages/*"

--- a/release.sh
+++ b/release.sh
@@ -1,7 +1,7 @@
-# this message appears when one of the commits found by web-scripts should trigger a release.
+# this message is logged by semantic-release when one of the commits found by web-scripts should trigger a release
 expected_release_message="The release type for the commit is"
 
-# run web-scripts release in dry-run mode, looking of the release message
+echo "spotify/web-scripts: Running semantic-release in --dry-run to see if we should trigger a lerna release."
 yarn web-scripts release --dry-run | grep "${expected_release_message}"
 
 if [ $? -eq 0 ]

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,15 @@
+# this message appears when one of the commits found by web-scripts should trigger a release.
+expected_release_message="The release type for the commit is"
+
+# run web-scripts release in dry-run mode, looking of the release message
+yarn web-scripts release --dry-run | grep "${expected_release_message}"
+
+if [ $? -eq 0 ]
+then
+  echo "spotify/web-scripts: A release will be triggered."
+  yarn lerna publish --yes --conventional-commits --registry=https://registry.npmjs.com
+  exit 0
+else
+  echo "spotify/web-scripts: No release will be triggered." >&2
+  exit 0
+fi


### PR DESCRIPTION
I wanted to use https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-recommended-bump to accomplish this, but it outputs "patch" for any commit, which is not what we want; we want non-releasing commits to be ignored for publishing.