### PR TITLE
fix(eslint-config-typescript): add no-useless-constructor override

### DIFF
--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -21,5 +21,8 @@ module.exports = {
     // no-unused-vars interference fix.
     'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': 'warn',
+    // no-useless-constructor interference fix.
+    'no-useless-constructor': 'off',
+    '@typescript-eslint/no-useless-constructor': 'error',
   },
 };


### PR DESCRIPTION
no-useless-constructor is one of those ESLint rules that fails to work properly in a TS app, like
no-unused-vars. an override must be provided for those using TypeScript.