### PR TITLE
feat(web-scripts lint): optional --stylecheck argument

### DIFF
--- a/packages/create-web-scripts-library/package.json
+++ b/packages/create-web-scripts-library/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "test": "web-scripts test",
     "build": "web-scripts build",
-    "lint": "web-scripts lint",
+    "lint": "web-scripts lint --stylecheck",
     "format": "web-scripts format",
     "prepublishOnly": "yarn run build"
   },

--- a/packages/web-scripts-utils/package.json
+++ b/packages/web-scripts-utils/package.json
@@ -18,7 +18,7 @@
     "clean": "rm -rf cjs esm types",
     "build": "web-scripts build",
     "test": "web-scripts test",
-    "lint": "web-scripts lint",
+    "lint": "web-scripts lint --stylecheck",
     "format": "web-scripts format",
     "bootstrap": "yarn run clean && tsc --allowJs --outDir cjs --noEmit false --module CommonJS && tsc --declaration --isolatedModules false --outDir types --emitDeclarationOnly --noEmit false",
     "prepublishOnly": "yarn run bootstrap && yarn run build"

--- a/packages/web-scripts/package.json
+++ b/packages/web-scripts/package.json
@@ -24,7 +24,7 @@
     "clean": "rm -rf cjs esm types",
     "build": "node ./bin/web-scripts build",
     "test": "node ./bin/web-scripts test",
-    "lint": "node ./bin/web-scripts lint",
+    "lint": "node ./bin/web-scripts lint --stylecheck",
     "format": "node ./bin/web-scripts format",
     "bootstrap": "yarn run clean && tsc --allowJs --outDir cjs --noEmit false --module CommonJS",
     "prepublishOnly": "yarn run bootstrap && yarn run build"

--- a/packages/web-scripts/src/SharedTypes.ts
+++ b/packages/web-scripts/src/SharedTypes.ts
@@ -29,6 +29,7 @@ export type TestTaskDesc = {
 export type LintTaskDesc = {
   name: 'lint';
   config?: string;
+  stylecheck: boolean;
   typecheck: boolean;
 } & TaskDesc;
 

--- a/packages/web-scripts/src/Tasks/LintTask.ts
+++ b/packages/web-scripts/src/Tasks/LintTask.ts
@@ -23,6 +23,7 @@ export function getEslintConfig(): string | null {
 export async function lintTask(task: LintTaskDesc): Promise<string[]> {
   const fns = [eslintRun];
   if (task.typecheck) fns.push(typeCheck);
+  if (task.stylecheck) fns.push(styleCheck);
 
   return await Promise.all(
     fns.map(async fn => {
@@ -62,6 +63,13 @@ async function eslintRun(task: LintTaskDesc): Promise<string> {
 async function typeCheck(): Promise<string> {
   const cmd = 'npx';
   const args = ['tsc', '--noEmit'];
+  const stdout = await spawn(cmd, args, { stdio: 'inherit' });
+  return (stdout || '').toString();
+}
+
+async function styleCheck(): Promise<string> {
+  const cmd = 'npx';
+  const args = ['prettier', '--check', `${CONSUMING_ROOT}/src/**/*.[jt]s?(x)`];
   const stdout = await spawn(cmd, args, { stdio: 'inherit' });
   return (stdout || '').toString();
 }

--- a/packages/web-scripts/src/Tasks/LintTask.ts
+++ b/packages/web-scripts/src/Tasks/LintTask.ts
@@ -4,6 +4,7 @@ import { hasConfig } from '@spotify/web-scripts-utils';
 
 import { LintTaskDesc } from '../SharedTypes';
 import { CONSUMING_ROOT, ESLINT_CONFIG } from '../Paths';
+import { getPrettierConfig } from './FormatTask';
 
 const dbg = Debug('web-scripts:lint'); // eslint-disable-line new-cap
 
@@ -69,7 +70,14 @@ async function typeCheck(): Promise<string> {
 
 async function styleCheck(): Promise<string> {
   const cmd = 'npx';
-  const args = ['prettier', '--check', `${CONSUMING_ROOT}/src/**/*.[jt]s?(x)`];
+  const args = ['prettier'];
+
+  const config = getPrettierConfig();
+  if (config) {
+    args.push('--config', config);
+  }
+
+  args.push('--check', `${CONSUMING_ROOT}/src/**/*.[jt]s?(x)`);
   const stdout = await spawn(cmd, args, { stdio: 'inherit' });
   return (stdout || '').toString();
 }

--- a/packages/web-scripts/src/index.ts
+++ b/packages/web-scripts/src/index.ts
@@ -77,13 +77,15 @@ program
   .description('Run ESLint and TypeScript to statically analyze your code')
   .option('--config [path]', 'path to ESLint config')
   .option('--typecheck', 'run a TypeScript type check')
+  .option('--stylecheck', "run Prettier's style check")
   .action((...args) => {
     const cmd = getCommand(args);
     const rest = getPositionalArgs(args);
-    const { typecheck, config } = getOpts(cmd);
+    const { stylecheck, typecheck, config } = getOpts(cmd);
     const t: LintTaskDesc = {
       name: 'lint',
       config,
+      stylecheck,
       typecheck,
       restOptions: [...parseRestOptions(cmd), ...rest],
     };

--- a/packages/web-scripts/src/integration.test.ts
+++ b/packages/web-scripts/src/integration.test.ts
@@ -78,7 +78,7 @@ describe('integration tests', () => {
 
     test(
       'Full integration test',
-      async () => await testScripts([], ['--typecheck']),
+      async () => await testScripts([], ['--typecheck', '--stylecheck']),
       TEST_SCRIPTS_TIMEOUT,
     );
   });


### PR DESCRIPTION
Resolves #72

## Status

Work In Progress

## Feature Intent

This task will run `prettier check` on the `src/` path at the location from which it was called. Prettier will check against a list of files with the extensions `.ts`, `.tsx`, `.js`, `.jsx` then return a subset of these files which do not meet the styling standards for the prettier configuration provided.

Note: As of writing this command does not currently integrate with ESLint intentionally.

## Testing Information

_Waiting on implementation feedback_

## References

[`prettier --check`](https://prettier.io/docs/en/cli.html#--check)