### PR TITLE
test(web-scripts): add a test for tests with jsx

### DIFF
--- a/packages/web-scripts/__fixtures__/Component.test.jsx
+++ b/packages/web-scripts/__fixtures__/Component.test.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+import { Component } from './Component';
+
+describe('testing JSX in tests', () => {
+  it('does not throw', () => {
+    expect(() => <Component />).not.toThrow();
+  });
+});

--- a/packages/web-scripts/__fixtures__/Component.test.tsx
+++ b/packages/web-scripts/__fixtures__/Component.test.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+import { Component } from './Component';
+
+describe('testing JSX in tests', () => {
+  it('does not throw', () => {
+    expect(() => <Component />).not.toThrow();
+  });
+});

--- a/packages/web-scripts/src/integration.test.ts
+++ b/packages/web-scripts/src/integration.test.ts
@@ -75,7 +75,12 @@ describe('integration tests', () => {
 
   describe('TypeScript', () => {
     beforeEach(async () => {
-      await setupRepo('index.ts', 'index.test.ts', 'Component.tsx');
+      await setupRepo(
+        'index.ts',
+        'index.test.ts',
+        'Component.tsx',
+        'Component.test.tsx',
+      );
     }, SETUP_REPO_TIMEOUT);
 
     test(
@@ -87,7 +92,12 @@ describe('integration tests', () => {
 
   describe('JavaScript', () => {
     beforeEach(async () => {
-      await setupRepo('index.js', 'index.test.js', 'Component.jsx');
+      await setupRepo(
+        'index.js',
+        'index.test.js',
+        'Component.jsx',
+        'Component.test.jsx',
+      );
     }, SETUP_REPO_TIMEOUT);
 
     test(
@@ -105,7 +115,6 @@ describe('integration tests', () => {
     // commands are run at the end.
     const localDependencies: string[] = [
       'eslint',
-      'react',
       'ts-jest',
       'typescript',
       '@types/jest',
@@ -113,9 +122,12 @@ describe('integration tests', () => {
       '@types/react-dom',
     ];
 
-    // as of ESLint 6, the TypeScript plugin needs to be installed
-    // more directly to be usable in this integration test.
-    const eslintDependencies: string[] = ['@typescript-eslint/eslint-plugin'];
+    // as of ESLint 6, ESLint plugins need to be locally installed too.
+    const eslintDependencies: string[] = [
+      '@typescript-eslint/eslint-plugin',
+      'eslint-plugin-jsx-a11y',
+      'eslint-plugin-react',
+    ];
 
     const pkg = {
       name: 'test-pkg',
@@ -133,6 +145,8 @@ describe('integration tests', () => {
         ...Object.entries(
           require(`${ESLINT_ROOT}/package.json`).dependencies,
         ).filter(([k]) => eslintDependencies.includes(k)),
+        // react isn't a local dependency so it needs to be directly specified
+        ['react', '^16'],
       ]),
     };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1583,15 +1583,6 @@
     regexpp "^3.0.0"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@2.14.0":
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.14.0.tgz#e9179fa3c44e00b3106b85d7b69342901fb43e3b"
-  integrity sha512-KcyKS7G6IWnIgl3ZpyxyBCxhkBPV+0a5Jjy2g5HxlrbG2ZLQNFeneIBVXdaBCYOVjvGmGGFKom1kgiAY75SDeQ==
-  dependencies:
-    "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.14.0"
-    eslint-scope "^5.0.0"
-
 "@typescript-eslint/experimental-utils@2.16.0":
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.16.0.tgz#bba65685728c532e0ddc811a0376e8d38e671f77"
@@ -1610,19 +1601,6 @@
     "@typescript-eslint/experimental-utils" "2.16.0"
     "@typescript-eslint/typescript-estree" "2.16.0"
     eslint-visitor-keys "^1.1.0"
-
-"@typescript-eslint/typescript-estree@2.14.0":
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.14.0.tgz#c67698acdc14547f095eeefe908958d93e1a648d"
-  integrity sha512-pnLpUcMNG7GfFFfNQbEX6f1aPa5fMnH2G9By+A1yovYI4VIOK2DzkaRuUlIkbagpAcrxQHLqovI1YWqEcXyRnA==
-  dependencies:
-    debug "^4.1.1"
-    eslint-visitor-keys "^1.1.0"
-    glob "^7.1.6"
-    is-glob "^4.0.1"
-    lodash.unescape "4.0.1"
-    semver "^6.3.0"
-    tsutils "^3.17.1"
 
 "@typescript-eslint/typescript-estree@2.16.0":
   version "2.16.0"
@@ -6091,11 +6069,6 @@ lodash.toarray@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
   integrity sha1-JMS/zWsvuji/0FlNsRedjptlZWE=
-
-lodash.unescape@4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
-  integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
 
 lodash.union@~4.6.0:
   version "4.6.0"


### PR DESCRIPTION
we found that an older version of web-scripts did not support JSX tests out of the box. This test
will ensure that we keep that working.