### PR TITLE
feat(index.js): Add react/jsx-curly-brace-presence rule

### DIFF
--- a/packages/eslint-config-react/index.js
+++ b/packages/eslint-config-react/index.js
@@ -13,6 +13,8 @@ module.exports = {
     'react/jsx-boolean-value': 2,
     // Enforce or disallow spaces inside of curly braces in JSX attributes
     'react/jsx-curly-spacing': 0,
+    // Enforce or disallow react string props to be wrapped in curly braces
+    'react/jsx-curly-brace-presence': 2,
     // Prevent duplicate props in JSX
     'react/jsx-no-duplicate-props': 0,
     // Disallow undeclared variables in JSX


### PR DESCRIPTION
We are running into an issue with inconsistency throughout our app when it comes to string props and string children of React elements. This rule, as it's set up in this PR, enforces the absence of curly braces for props or children when passing strings.

props: `<App foo="bar" />` is enforced
children: `<App>Foo</App>` is enforced

This rule is auto fixable, so migration should be easy.  Please let me know thoughts on this and the current settings.

This does feel like a code style, but the prettier folks seemed opinionated that this should be handled in linting.  Would love to hear your thoughts :)
https://github.com/prettier/prettier/issues/3303

Documentation: https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-brace-presence.md