### PR TITLE
fix(eslint-config-base): allow triple slashes

### DIFF
--- a/packages/eslint-config-base/es5.js
+++ b/packages/eslint-config-base/es5.js
@@ -317,7 +317,7 @@ module.exports = {
       'always',
       {
         exceptions: ['-', '+'],
-        markers: ['=', '!'], // space here to support sprockets directives
+        markers: ['=', '!', '/'], // space here to support sprockets directives
       },
     ],
     // require regex literals to be wrapped in parentheses


### PR DESCRIPTION
triple slashes are used in TypeScript declarations. The ESLint rule spaced-comment can interfere
with them, especially when using `--fix`.

fix #117