### PR TITLE
Feat/use eslint plugin jest

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -28,6 +28,7 @@ module.exports = {
     'prettier',
     hasReact ? 'prettier/react' : null,
     hasTypescript ? 'prettier/@typescript-eslint' : null,
+    'plugin:jest/recommended',
   ].filter(s => !!s),
   parser: '@typescript-eslint/parser',
   env: {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -24,6 +24,7 @@
     "@typescript-eslint/eslint-plugin": "^2.14.0",
     "@typescript-eslint/parser": "^2.14.0",
     "eslint-config-prettier": "^6.0.0",
+    "eslint-plugin-jest": "^23.6.0",
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-react": "^7.12.4"
   },

--- a/packages/web-scripts/src/integration.test.ts
+++ b/packages/web-scripts/src/integration.test.ts
@@ -1,4 +1,3 @@
-import 'jest';
 import { exec as execCP } from 'child_process';
 import { join } from 'path';
 import { promisify } from 'util';

--- a/packages/web-scripts/src/integration.test.ts
+++ b/packages/web-scripts/src/integration.test.ts
@@ -125,6 +125,7 @@ describe('integration tests', () => {
     // as of ESLint 6, ESLint plugins need to be locally installed too.
     const eslintDependencies: string[] = [
       '@typescript-eslint/eslint-plugin',
+      'eslint-plugin-jest',
       'eslint-plugin-jsx-a11y',
       'eslint-plugin-react',
     ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1756,7 +1756,7 @@
     regexpp "^3.0.0"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@2.17.0":
+"@typescript-eslint/experimental-utils@2.17.0", "@typescript-eslint/experimental-utils@^2.5.0":
   version "2.17.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.17.0.tgz#12ed4a5d656e02ff47a93efc7d1ce1b8f1242351"
   integrity sha512-2bNf+mZ/3mj5/3CP56v+ldRK3vFy9jOvmCPs/Gr2DeSJh+asPZrhFniv4QmQsHWQFPJFWhFHgkGgJeRmK4m8iQ==
@@ -3573,6 +3573,14 @@ eslint-config-prettier@^6.0.0:
   integrity sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==
   dependencies:
     get-stdin "^6.0.0"
+
+eslint-plugin-jest@^23.6.0:
+  version "23.6.0"
+  resolved "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-23.6.0.tgz#508b32f80d44058c8c01257c0ee718cfbd521e9d"
+  integrity sha512-GH8AhcFXspOLqak7fqnddLXEJsrFyvgO8Bm60SexvKSn1+3rWYESnCiWUOCUcBTprNSDSE4CtAZdM4EyV6gPPw==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "^2.5.0"
+    micromatch "^4.0.2"
 
 eslint-plugin-jsx-a11y@^6.2.1:
   version "6.2.3"


### PR DESCRIPTION
eslint-plugin-jest provides a bunch of [rules](https://github.com/jest-community/eslint-plugin-jest#rules) that help write better Jest tests. In particular, the
rules that prevent disabling or focusing tests are a really great way to ensure that tests aren't
being accidentally ignored. This commit adds the recommended settings to the config exported by
@spotify/eslint-config, so they'll be enabled automatically for everyone.

nb: based on previous discussions on this repo, I _think_ this isn't considered a breaking change, but let me know!