### PR TITLE
fix(create-web-scripts-library): format package.json

### DIFF
--- a/packages/create-web-scripts-library/src/index.ts
+++ b/packages/create-web-scripts-library/src/index.ts
@@ -37,7 +37,7 @@ export default async function createWebScriptsLibrary(projectName?: string) {
   newPkg.devDependencies['@spotify/web-scripts'] =
     (cwslPkg?.devDependencies || {})['@spotify/web-scripts'] ||
     newPkg.devDependencies['@spotify/web-scripts'];
-  await fs.writeFile(newPkgPath, JSON.stringify(newPkg));
+  await fs.writeFile(newPkgPath, JSON.stringify(newPkg, null, 2));
 
   console.log(chalk.gray('Installing dependencies...'));
   process.chdir(projectPath);


### PR DESCRIPTION
When running `yarn create @spotify/web-scripts-library` you end up with a `package.json` that is not nicely formatted (single line JSON string). This should fix that and make the created `package.json` correctly indented 🙂 