### PR TITLE
docs(eslint-config): rename .eslintrc to .eslintrc.json

### DIFF
--- a/packages/eslint-config-base/README.md
+++ b/packages/eslint-config-base/README.md
@@ -10,7 +10,7 @@ yarn add --dev @spotify/eslint-config-base eslint
 
 ## Usage
 
-After installing, update your project's `.eslintrc` file to import the rule sets you want:
+After installing, update your project's `.eslintrc.json` file to import the rule sets you want:
 
 ```js
 {

--- a/packages/eslint-config-react/README.md
+++ b/packages/eslint-config-react/README.md
@@ -10,7 +10,7 @@ yarn add --dev @spotify/eslint-config-react eslint eslint-plugin-react eslint-pl
 
 ## Usage
 
-After installing, update your project's `.eslintrc` file to import the rule sets you want:
+After installing, update your project's `.eslintrc.json` file to import the rule sets you want:
 
 ```js
 {

--- a/packages/eslint-config-typescript/README.md
+++ b/packages/eslint-config-typescript/README.md
@@ -10,7 +10,7 @@ npm install --save-dev @spotify/eslint-config-typescript
 
 ## Usage
 
-After installing, update your project's `.eslintrc` file to import the rule sets you want:
+After installing, update your project's `.eslintrc.json` file to import the rule sets you want:
 
 ```js
 {


### PR DESCRIPTION
.eslintrc is deprecated (https://eslint.org/docs/user-guide/configuring)