### PR TITLE
fix: remove `noEmit` default value

### DIFF
--- a/packages/create-web-scripts-library/package.json
+++ b/packages/create-web-scripts-library/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "test": "web-scripts test",
     "build": "web-scripts build",
-    "lint": "web-scripts lint --stylecheck",
+    "lint": "web-scripts lint --stylecheck --typecheck",
     "format": "web-scripts format",
     "prepublishOnly": "yarn run build"
   },

--- a/packages/tsconfig/README.md
+++ b/packages/tsconfig/README.md
@@ -16,11 +16,4 @@ yarn add --dev @spotify/tsconfig
 
 For more information, check out our [docs on GitHub].
 
-## Contributing
-
-Try to optimize for the fewest specified options between the config specializations. For example, only `app` has `noEmit: true`, since the [default value][compiler options], `false`, is good for the `lib` config. Specifying it only in the `app` config means fewer overall entries!
-
-We want to keep maintenance low by only specifying what is necessary. If the option's [default value][compiler options] is good for every config, remove it from every config!
-
-[compiler options]: https://www.typescriptlang.org/docs/handbook/compiler-options.html
 [docs on github]: ./docs

--- a/packages/tsconfig/docs/examples.md
+++ b/packages/tsconfig/docs/examples.md
@@ -2,7 +2,7 @@
 
 ## Getting started
 
-This project outputs a single tsconfig.json file for use. This file is configured to disable all output options (`declaration` is `false`, `noEmit` is true) and is set to strictly type check your code (for example, `noImplicitAny` and many other strict type checks). It is likely that you will need to import this file and do a little configuration additionally depending on whether you plan to use this configuration in conjunction with Webpack or Babel, or whether you plan to use `tsc` to output artifacts.
+This project outputs a single tsconfig.json file for use. This file is set to strictly type check your code (for example, `noImplicitAny` and many other strict type checks). It is likely that you will need to import this file and do a little configuration additionally depending on whether you plan to use this configuration in conjunction with Webpack or Babel, or whether you plan to use `tsc` to output artifacts.
 
 ### Questions to answer
 
@@ -63,17 +63,6 @@ module.exports = {
 };
 ```
 
-**IMPORTANT** You will need to turn off `noEmit` when using `ts-loader` with `@spotify/tsconfig`:
-
-```json
-{
-  "extends": "@spotify/tsconfig",
-  "compilerOptions": {
-    "noEmit": false
-  }
-}
-```
-
 ## Libraries
 
 ### @spotify/web-scripts
@@ -95,7 +84,6 @@ Essentially, this config takes the base config and extends it to output Common J
   "extends": "@spotify/tsconfig",
   "include": ["src"],
   "compilerOptions": {
-    "noEmit": false,
     "outDir": "dist",
     "declaration": true,
     "declarationMap": true,

--- a/packages/tsconfig/tsconfig.json
+++ b/packages/tsconfig/tsconfig.json
@@ -8,7 +8,6 @@
     "isolatedModules": true,
     "module": "esnext",
     "moduleResolution": "node",
-    "noEmit": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": true,
     "noImplicitReturns": true,

--- a/packages/web-scripts-utils/package.json
+++ b/packages/web-scripts-utils/package.json
@@ -18,9 +18,9 @@
     "clean": "rm -rf cjs esm types",
     "build": "web-scripts build",
     "test": "web-scripts test",
-    "lint": "web-scripts lint --stylecheck",
+    "lint": "web-scripts lint --stylecheck --typecheck",
     "format": "web-scripts format",
-    "bootstrap": "yarn run clean && tsc --allowJs --outDir cjs --noEmit false --module CommonJS && tsc --declaration --isolatedModules false --outDir types --emitDeclarationOnly --noEmit false",
+    "bootstrap": "yarn run clean && tsc --allowJs --outDir cjs --module CommonJS && tsc --declaration --isolatedModules false --outDir types --emitDeclarationOnly ",
     "prepublishOnly": "yarn run bootstrap && yarn run build"
   },
   "dependencies": {

--- a/packages/web-scripts-utils/tsconfig.json
+++ b/packages/web-scripts-utils/tsconfig.json
@@ -1,10 +1,4 @@
 {
   "extends": "@spotify/tsconfig",
-  "include": ["src"],
-  "compilerOptions": {
-    "isolatedModules": false,
-    "noEmit": true,
-    "declaration": false,
-    "jsx": "preserve"
-  }
+  "include": ["src"]
 }

--- a/packages/web-scripts/package.json
+++ b/packages/web-scripts/package.json
@@ -24,9 +24,9 @@
     "clean": "rm -rf cjs esm types",
     "build": "node ./bin/web-scripts build",
     "test": "node ./bin/web-scripts test",
-    "lint": "node ./bin/web-scripts lint --stylecheck",
+    "lint": "node ./bin/web-scripts lint --stylecheck --typecheck",
     "format": "node ./bin/web-scripts format",
-    "bootstrap": "yarn run clean && tsc --allowJs --outDir cjs --noEmit false --module CommonJS",
+    "bootstrap": "yarn run clean && tsc --allowJs --outDir cjs --module CommonJS",
     "prepublishOnly": "yarn run bootstrap && yarn run build"
   },
   "dependencies": {
@@ -47,8 +47,8 @@
     "cz-conventional-changelog": "^3.0.2",
     "debug": "^4.1.1",
     "eslint": "^6.8.0",
-    "jest": "^25.1.0",
-    "jest-config": "^25.1.0",
+    "jest": "^25.2.7",
+    "jest-config": "^25.2.7",
     "jest-junit": "^10.0.0",
     "lint-staged": "^10.0.4",
     "prettier": "^1.18.2",

--- a/packages/web-scripts/src/Tasks/BuildTask.ts
+++ b/packages/web-scripts/src/Tasks/BuildTask.ts
@@ -59,6 +59,8 @@ async function buildTypes(task: BuildTaskDesc): Promise<string> {
     '--emitDeclarationOnly',
     '--noEmit',
     'false',
+    '--incremental',
+    'true',
     ...task.restOptions,
   ];
   const stdout = await spawn(cmd, args, { stdio: 'inherit' });
@@ -74,6 +76,8 @@ async function buildCJS(task: BuildTaskDesc): Promise<string> {
     'cjs',
     '--noEmit',
     'false',
+    '--incremental',
+    'true',
     '--module',
     'CommonJS',
     ...task.restOptions,
@@ -91,6 +95,8 @@ async function buildESM(task: BuildTaskDesc): Promise<string> {
     'esm',
     '--noEmit',
     'false',
+    '--incremental',
+    'true',
     '--module',
     'ES2015',
     ...task.restOptions,

--- a/packages/web-scripts/src/Tasks/LintTask.ts
+++ b/packages/web-scripts/src/Tasks/LintTask.ts
@@ -78,7 +78,7 @@ export async function eslintRun(task: LintTaskDesc): Promise<string> {
 
 export async function typeCheck(): Promise<string> {
   const cmd = 'npx';
-  const args = ['tsc', '--noEmit'];
+  const args = ['tsc', '--noEmit', 'true', '--incremental', 'false'];
   const stdout = await spawn(cmd, args, { stdio: 'inherit' });
   return (stdout || '').toString();
 }

--- a/packages/web-scripts/tsconfig.json
+++ b/packages/web-scripts/tsconfig.json
@@ -1,9 +1,4 @@
 {
   "extends": "@spotify/tsconfig",
-  "include": ["src"],
-  "compilerOptions": {
-    "isolatedModules": false,
-    "noEmit": true,
-    "jsx": "preserve"
-  }
+  "include": ["src"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1941,16 +1941,6 @@
     regexpp "^3.0.0"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@2.28.0":
-  version "2.28.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.28.0.tgz#1fd0961cd8ef6522687b4c562647da6e71f8833d"
-  integrity sha512-4SL9OWjvFbHumM/Zh/ZeEjUFxrYKtdCi7At4GyKTbQlrj1HcphIDXlje4Uu4cY+qzszR5NdVin4CCm6AXCjd6w==
-  dependencies:
-    "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.28.0"
-    eslint-scope "^5.0.0"
-    eslint-utils "^2.0.0"
-
 "@typescript-eslint/experimental-utils@2.29.0", "@typescript-eslint/experimental-utils@^2.5.0":
   version "2.29.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.29.0.tgz#3cb8060de9265ba131625a96bbfec31ba6d4a0fe"
@@ -1970,19 +1960,6 @@
     "@typescript-eslint/experimental-utils" "2.29.0"
     "@typescript-eslint/typescript-estree" "2.29.0"
     eslint-visitor-keys "^1.1.0"
-
-"@typescript-eslint/typescript-estree@2.28.0":
-  version "2.28.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.28.0.tgz#d34949099ff81092c36dc275b6a1ea580729ba00"
-  integrity sha512-HDr8MP9wfwkiuqzRVkuM3BeDrOC4cKbO5a6BymZBHUt5y/2pL0BXD6I/C/ceq2IZoHWhcASk+5/zo+dwgu9V8Q==
-  dependencies:
-    debug "^4.1.1"
-    eslint-visitor-keys "^1.1.0"
-    glob "^7.1.6"
-    is-glob "^4.0.1"
-    lodash "^4.17.15"
-    semver "^6.3.0"
-    tsutils "^3.17.1"
 
 "@typescript-eslint/typescript-estree@2.29.0":
   version "2.29.0"
@@ -5641,7 +5618,31 @@ jest-cli@^25.4.0:
     realpath-native "^2.0.0"
     yargs "^15.3.1"
 
-jest-config@^25.1.0, jest-config@^25.3.0:
+jest-config@^25.2.7:
+  version "25.2.7"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-25.2.7.tgz#a14e5b96575987ce913dd9fc20ac8cd4b35a8c29"
+  integrity sha512-rIdPPXR6XUxi+7xO4CbmXXkE6YWprvlKc4kg1SrkCL2YV5m/8MkHstq9gBZJ19Qoa3iz/GP+0sTG/PcIwkFojg==
+  dependencies:
+    "@babel/core" "^7.1.0"
+    "@jest/test-sequencer" "^25.2.7"
+    "@jest/types" "^25.2.6"
+    babel-jest "^25.2.6"
+    chalk "^3.0.0"
+    deepmerge "^4.2.2"
+    glob "^7.1.1"
+    jest-environment-jsdom "^25.2.6"
+    jest-environment-node "^25.2.6"
+    jest-get-type "^25.2.6"
+    jest-jasmine2 "^25.2.7"
+    jest-regex-util "^25.2.6"
+    jest-resolve "^25.2.6"
+    jest-util "^25.2.6"
+    jest-validate "^25.2.6"
+    micromatch "^4.0.2"
+    pretty-format "^25.2.6"
+    realpath-native "^2.0.0"
+
+jest-config@^25.3.0:
   version "25.3.0"
   resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-25.3.0.tgz#112b5e2f2e57dec4501dd2fe979044c06fb1317e"
   integrity sha512-CmF1JnNWFmoCSPC4tnU52wnVBpuxHjilA40qH/03IHxIevkjUInSMwaDeE6ACfxMPTLidBGBCO3EbxvzPbo8wA==
@@ -6263,14 +6264,14 @@ jest-worker@^25.4.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
-jest@^25.1.0:
-  version "25.4.0"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-25.4.0.tgz#fb96892c5c4e4a6b9bcb12068849cddf4c5f8cc7"
-  integrity sha512-XWipOheGB4wai5JfCYXd6vwsWNwM/dirjRoZgAa7H2wd8ODWbli2AiKjqG8AYhyx+8+5FBEdpO92VhGlBydzbw==
+jest@^25.2.7:
+  version "25.2.7"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-25.2.7.tgz#3929a5f35cdd496f7756876a206b99a94e1e09ae"
+  integrity sha512-XV1n/CE2McCikl4tfpCY950RytHYvxdo/wvtgmn/qwA8z1s16fuvgFL/KoPrrmkqJTaPMUlLVE58pwiaTX5TdA==
   dependencies:
-    "@jest/core" "^25.4.0"
+    "@jest/core" "^25.2.7"
     import-local "^3.0.2"
-    jest-cli "^25.4.0"
+    jest-cli "^25.2.7"
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
`noEmit` interferes with many recent flags added to tsc, such as `incremental`. we've decided it
will be best to configure `noEmit` directly on the commands where we know it's needed, such as
linting and building, using cli arguments, and to leave it out of the tsconfigs. this should make
testing and webpacking much simpler with our configs.

BREAKING CHANGE: your builds will potentially produce artifacts at unexpected times depending on
your local tscsonfig.json

fixes #252