### PR TITLE
fix(web-scripts): positional args were being stripped out

### DIFF
--- a/packages/web-scripts/src/index.ts
+++ b/packages/web-scripts/src/index.ts
@@ -62,7 +62,7 @@ program
       esm,
       types,
       cjs,
-      restOptions: parseRestOptions(cmd),
+      restOptions: cmd.args,
     };
 
     handlePromiseResult(buildTask(t));
@@ -79,7 +79,7 @@ program
     const t: TestTaskDesc = {
       name: 'test',
       config,
-      restOptions: parseRestOptions(cmd),
+      restOptions: cmd.args,
     };
 
     const result = testTask(t);
@@ -103,7 +103,7 @@ program
       config,
       stylecheck,
       typecheck,
-      restOptions: parseRestOptions(cmd),
+      restOptions: cmd.args,
     };
 
     handlePromiseResult(lintTask(t));
@@ -125,7 +125,7 @@ program
       name: 'format',
       config,
       path,
-      restOptions: parseRestOptions(cmd),
+      restOptions: cmd.args,
     };
 
     handleSpawnResult(formatTask(t));
@@ -156,7 +156,7 @@ program
       jestConfig,
       eslintConfig,
       prettierConfig,
-      restOptions: parseRestOptions(cmd),
+      restOptions: cmd.args,
     };
 
     handlePromiseResult(precommitTask(t));
@@ -194,7 +194,7 @@ program
     const t: AuditTaskDesc = {
       name: 'audit',
       threshold,
-      restOptions: parseRestOptions(cmd),
+      restOptions: cmd.args,
     };
 
     handlePromiseResult(auditTask(t));
@@ -215,7 +215,7 @@ program
     const t: CommitTaskDesc = {
       name: 'commit',
       path,
-      restOptions: parseRestOptions(cmd),
+      restOptions: cmd.args,
     };
 
     try {
@@ -240,7 +240,7 @@ program
     const t: CommitMsgTaskDesc = {
       name: 'commitmsg',
       config,
-      restOptions: parseRestOptions(cmd),
+      restOptions: cmd.args,
     };
 
     handleSpawnResult(commitMsgTask(t));
@@ -254,7 +254,7 @@ program
     const cmd = getCommand(args);
     const t: ReleaseTaskDesc = {
       name: 'release',
-      restOptions: parseRestOptions(cmd),
+      restOptions: cmd.args,
     };
 
     handleSpawnResult(releaseTask(t));
@@ -290,10 +290,6 @@ function getCommand(args: any[]): Command {
 
 function getOpts(cmd: Command): { [key: string]: any } {
   return cmd.opts();
-}
-
-function parseRestOptions(cmd: Command): string[] {
-  return cmd.parseOptions(process.argv).unknown;
 }
 
 program.parse(process.argv);

--- a/packages/web-scripts/src/integration.test.ts
+++ b/packages/web-scripts/src/integration.test.ts
@@ -92,6 +92,7 @@ describe('integration tests', () => {
       );
     }, SETUP_REPO_TIMEOUT);
 
+    // eslint-disable-next-line jest/expect-expect
     test(
       'Full integration test',
       async () => await testScripts(),
@@ -109,6 +110,7 @@ describe('integration tests', () => {
       );
     }, SETUP_REPO_TIMEOUT);
 
+    // eslint-disable-next-line jest/expect-expect
     test(
       'Full integration test',
       async () => await testScripts(['--no-types'], ['--no-typecheck']),


### PR DESCRIPTION
the best test case for this is `web-scripts test filename`, which currently doesn't work.

positional args were not making there way through to the web-scripts commands, because commander 5 changed how we need to handle args. there is now conveniently an `args` array on the command which contains all args (positional or flagged) in order, which seems to be more reliably correct from what the user inputs compared to using the `parseOptions(process.argv)` method.