### PR TITLE
Move Jest-specific eslint config into a separate package

### DIFF
--- a/packages/eslint-config-jest/README.md
+++ b/packages/eslint-config-jest/README.md
@@ -1,0 +1,45 @@
+# @spotify/eslint-config-jest
+
+Spotify's TypeScript full ESLint config.
+
+## Installation
+
+```sh
+npm install --save-dev eslint @spotify/eslint-config
+```
+
+## Usage
+
+After installing, update your project's ESLint config:
+
+```json
+{
+  "extends": ["@spotify/eslint-config-jest"]
+}
+```
+
+It will often be useful to extend this configuration only for test files. This way, eslint will warn you if you try to use things like Jest globals in non-test code:
+
+```js
+{
+  "extends": ["@spotify"],
+  "overrides": [
+    {
+      // If you override Jest's testMatch configuration,
+      // adjust this setting to match.
+      //
+      // cf. https://jestjs.io/docs/en/configuration.html#testmatch-arraystring
+      files: [
+        '**/{__tests__,__mocks__}/**/*.{js,jsx,ts,tsx}',
+        '**/*.{spec,test}.{js,jsx,ts,tsx}'
+      ],
+      "extends": ["@spotify/eslint-config-jest"]
+    }
+  ]
+}
+```
+
+---
+
+Read the [ESlint config docs](http://eslint.org/docs/user-guide/configuring#extending-configuration-files)
+for more information.

--- a/packages/eslint-config-jest/index.js
+++ b/packages/eslint-config-jest/index.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module.exports = {
+  extends: ['@spotify', 'plugin:jest/recommended'],
+  env: {
+    jest: true,
+  },
+};

--- a/packages/eslint-config-jest/package.json
+++ b/packages/eslint-config-jest/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@spotify/eslint-config-jest",
+  "version": "7.0.0",
+  "description": "Spotify's eslint config for Jest test files",
+  "author": "Paul Marbach <pmarbach@spotify.com>",
+  "homepage": "https://github.com/spotify/web-scripts#readme",
+  "license": "Apache-2.0",
+  "main": "index.js",
+  "files": [
+    "index.js"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/spotify/web-scripts.git"
+  },
+  "bugs": {
+    "url": "https://github.com/spotify/web-scripts/issues"
+  },
+  "scripts": {},
+  "dependencies": {
+    "@spotify/eslint-config": "^7.0.1",
+    "eslint-plugin-jest": "^23.6.0"
+  },
+  "devDependencies": {
+    "eslint": "^6.8.0"
+  },
+  "peerDependencies": {
+    "eslint": ">=6.x"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=10.18.0"
+  }
+}

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -18,6 +18,29 @@ After installing, update your project's ESLint config:
 }
 ```
 
+### Linting Jest code
+
+This configuration does not support Jest out of the box. If you want to configure eslint for your Jest unit test code too, you can use this package and @spotify/eslint-config-jest together:
+
+```js
+{
+  "extends": ["@spotify"],
+  "overrides": [
+    {
+      // If you override Jest's testMatch configuration,
+      // adjust this setting to match.
+      //
+      // cf. https://jestjs.io/docs/en/configuration.html#testmatch-arraystring
+      files: [
+        '**/{__tests__,__mocks__}/**/*.{js,jsx,ts,tsx}',
+        '**/*.{spec,test}.{js,jsx,ts,tsx}'
+      ],
+      "extends": ["@spotify/eslint-config-jest"]
+    }
+  ]
+}
+```
+
 ---
 
 Read the [ESlint config docs](http://eslint.org/docs/user-guide/configuring#extending-configuration-files)

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -43,12 +43,8 @@ module.exports = {
     'prettier',
     hasReact ? 'prettier/react' : null,
     hasTypescript ? 'prettier/@typescript-eslint' : null,
-    'plugin:jest/recommended',
   ].filter(s => !!s),
   parser: '@typescript-eslint/parser',
-  env: {
-    jest: true,
-  },
   parserOptions: {
     ecmaVersion: 2018,
     sourceType: 'module',

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -25,7 +25,6 @@
     "@typescript-eslint/eslint-plugin": "^2.14.0",
     "@typescript-eslint/parser": "^2.14.0",
     "eslint-config-prettier": "^6.0.0",
-    "eslint-plugin-jest": "^23.6.0",
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-react": "^7.12.4",
     "eslint-plugin-react-hooks": "^4.0.0"


### PR DESCRIPTION
This PR removes all Jest-specific configuration from `@spotify/eslint-config`, and creates a separate package `@spotify/eslint-config-jest` for it instead. This allows people to add Jest configuration for the specifically files where it makes sense, which has two main benefits:

1. It means that Jest globals are not treated as in scope in non-test files, which means eslint will report any incorrect references to these globals when they're actually expected to be out of scope.
2. It makes it easier for other test frameworks like Cypress to coexist with Jest code in a single repository; with this change, it's now easy to have one eslint overrides rule for Cypress code, and another for Jest code.

The second commit will produce new linting errors for almost everyone, and people will need to update their eslint configuration as described in the README changes proposed in this PR to fix the errors. As such I've marked the second commit as a breaking change for now, but happy to discuss further.