### PR TITLE
fix(eslint-config-typescript): turn off naming-convention

### DIFF
--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -26,25 +26,7 @@ module.exports = {
   rules: {
     // camelcase interference fix.
     camelcase: 'off',
-    '@typescript-eslint/naming-convention': [
-      'error',
-      {
-        selector: 'default',
-        format: ['camelCase', 'UPPER_CASE', 'PascalCase'],
-        leadingUnderscore: 'allow',
-      },
-
-      {
-        selector: 'parameter',
-        format: ['camelCase'],
-        leadingUnderscore: 'allow',
-      },
-
-      {
-        selector: 'typeLike',
-        format: ['PascalCase'],
-      },
-    ],
+    '@typescript-eslint/naming-convention': 'off',
     // indent interference fix.
     indent: 'off',
     '@typescript-eslint/indent': ['error', 2, { SwitchCase: 1 }],


### PR DESCRIPTION
the new naming-convention config flunked many linters. for now, we will disable the config and
re-evaluate whether something that better matches our methodology can be used instead.