### PR TITLE
feat(eslint-spotify): add new eslint-spotify package with no-react-fc rule

### DIFF
--- a/packages/eslint-spotify/README.md
+++ b/packages/eslint-spotify/README.md
@@ -1,0 +1,32 @@
+# @spotify/eslint-spotify
+
+This contains all Spotify-specific eslint rules.
+
+## Installation
+
+```sh
+npm install --save-dev eslint @spotify/eslint-spotify
+```
+
+## Rules
+
+| Category | Name                  | Description                                                             |
+| -------- | --------------------- | ----------------------------------------------------------------------- |
+| React    | [`react/no-react-fc`] | Prevents usage of `React.FC`, `React.SFC` and `React.FunctionComponent` |
+
+[`react/no-react-fc`]: https://github.com/spotify/web-scripts/blob/master/packages/eslint-spotify/src/rules/react/no-react-fc.md
+
+## Usage
+
+After installing, update your project's `.eslintrc.json` config:
+
+```js
+{
+  "extends" : ["@spotify/eslint-spotify"]
+}
+```
+
+---
+
+Read the [ESlint config docs](http://eslint.org/docs/user-guide/configuring#extending-configuration-files)
+for more information.

--- a/packages/eslint-spotify/package.json
+++ b/packages/eslint-spotify/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@spotify/eslint-spotify",
+  "version": "8.0.1",
+  "description": "Set of rules for Spotify's custom ESLint rules",
+  "author": "Bilawal Hameed <bil@spotify.com>",
+  "homepage": "https://github.com/spotify/web-scripts/blob/master/packages/eslint-spotify#readme",
+  "keywords": [
+    "eslint",
+    "eslint-plugin",
+    "react",
+    "typescript"
+  ],
+  "license": "Apache-2.0",
+  "main": "cjs/index.js",
+  "module": "esm/index.js",
+  "types": "types",
+  "files": [
+    "cjs",
+    "esm",
+    "types"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/spotify/web-scripts.git",
+    "directory": "packages/eslint-spotify"
+  },
+  "bugs": {
+    "url": "https://github.com/spotify/web-scripts/issues"
+  },
+  "scripts": {
+    "build": "web-scripts build",
+    "test": "web-scripts test",
+    "lint": "web-scripts lint --stylecheck",
+    "format": "web-scripts format"
+  },
+  "devDependencies": {
+    "@spotify/web-scripts": "^8.0.1",
+    "@types/eslint": "^7.2.0",
+    "@types/jest": "^26.0.0",
+    "@typescript-eslint/parser": "^3.4.0",
+    "@typescript-eslint/types": "^3.6.1",
+    "eslint": "^7.3.1",
+    "typescript": "^3.9.6"
+  },
+  "peerDependencies": {
+    "@typescript-eslint/parser": "^3.0.0",
+    "eslint": ">=7.x"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=10.18.0"
+  }
+}

--- a/packages/eslint-spotify/src/index.ts
+++ b/packages/eslint-spotify/src/index.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export default {
+  'react/no-react-fc': require('./rules/react/no-react-fc'),
+};

--- a/packages/eslint-spotify/src/rules/react/no-react-fc.md
+++ b/packages/eslint-spotify/src/rules/react/no-react-fc.md
@@ -1,0 +1,28 @@
+# Prevent usage of React.FC (react/no-react-fc)
+
+Use in order to prevent usage of either `React.FC`, `React.SFC` or `React.FunctionComponent` which are no longer being used by React and Facebook. The core reason being that it was found to be an unnecessary feature with next to no benefits in combination with a few downsides.
+
+It is expected that over the next year, these React types will be phased out.
+
+```
+"react/no-react-fc": "error"
+```
+
+In the [Backstage](https://github.com/spotify/backstage), there is also an ADR (architecture decision record) to phase this out for their project. [See the ADR here](https://github.com/spotify/backstage/blob/master/docs/architecture-decisions/adr006-avoid-react-fc.md>).
+
+## Rule details
+
+This rule will raise the following error whenever you refer, in any way, the `React.FC`, `React.SFC` or `React.FunctionComponent` declarations.
+
+> Usage of React.FC and React.SFC types are discouraged when creating React components.
+
+Note, it doesn't perform deep type checks to validate if you are using the "true" definitions from React. It simply performs validation on the names.
+
+To skip for specific files, simply prepend the appropriate line wiht:
+
+```tsx
+// eslint-disable-next-line react/no-react-fc
+const UserProfile: React.FC<{ name: string }> = ({ name }) => {
+  return <h1>User: {name}</h1>;
+};
+```

--- a/packages/eslint-spotify/src/rules/react/no-react-fc.test.ts
+++ b/packages/eslint-spotify/src/rules/react/no-react-fc.test.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import rule from './no-react-fc';
+import { createRuleTester } from '../../util/testHelpers';
+
+const defaultErrorMessage: string =
+  'Usage of React.FC and React.SFC types are discouraged when creating React components.';
+
+createRuleTester().run('react/no-react-fc', rule, {
+  valid: [
+    {
+      code: 'var HelloWorld = () => {};',
+    },
+    {
+      code: 'var HelloWorld = ({ enable }: { enable: boolean }) => {};',
+    },
+    {
+      code: 'var HelloWorld = (): ReactNode => {};',
+    },
+    {
+      code: 'var HelloWorld = (): Custom.FC => {};',
+    },
+    {
+      code: 'var HelloWorld = (): Custom.SFC => {};',
+    },
+    {
+      code: 'var HelloWorld = (): Custom.FunctionComponent => {};',
+    },
+    {
+      code: 'var HelloWorld = (): Custom.React.FC => {};',
+    },
+    {
+      code: 'var HelloWorld = (): Custom.React.SFC => {};',
+    },
+    {
+      code: 'var HelloWorld = (): Custom.React.FunctionComponent => {};',
+    },
+  ],
+  invalid: [
+    {
+      code: `var HelloWorld: FC<{}> = () => {};`,
+      errors: [defaultErrorMessage],
+    },
+    {
+      code: `var HelloWorld: SFC<{}> = () => {};`,
+      errors: [defaultErrorMessage],
+    },
+    {
+      code: `var HelloWorld: FunctionComponent<{}> = () => {};`,
+      errors: [defaultErrorMessage],
+    },
+    {
+      code: `var HelloWorld: React.FC<{}> = () => {};`,
+      errors: [defaultErrorMessage],
+    },
+    {
+      code: `var HelloWorld: React.SFC<{}> = () => {};`,
+      errors: [defaultErrorMessage],
+    },
+    {
+      code: `var HelloWorld: React.FunctionComponent<{}> = () => {};`,
+      errors: [defaultErrorMessage],
+    },
+    {
+      code: `
+        type FakeFC = FC;
+        var HelloWorld: FakeFC<{}> = () => {};
+      `,
+      errors: [defaultErrorMessage],
+    },
+    {
+      code: `
+        type FakeFC = SFC;
+        var HelloWorld: FakeFC<{}> = () => {};
+      `,
+      errors: [defaultErrorMessage],
+    },
+    {
+      code: `
+        type FakeFC = FunctionComponent;
+        var HelloWorld: FakeFC<{}> = () => {};
+      `,
+      errors: [defaultErrorMessage],
+    },
+    {
+      code: `
+        type FakeFC = React.FC;
+        var HelloWorld: FakeFC<{}> = () => {};
+      `,
+      errors: [defaultErrorMessage],
+    },
+    {
+      code: `
+        type FakeFC = React.SFC;
+        var HelloWorld: FakeFC<{}> = () => {};
+      `,
+      errors: [defaultErrorMessage],
+    },
+    {
+      code: `
+        type FakeFC = React.FunctionComponent;
+        var HelloWorld: FakeFC<{}> = () => {};
+      `,
+      errors: [defaultErrorMessage],
+    },
+  ],
+});

--- a/packages/eslint-spotify/src/rules/react/no-react-fc.ts
+++ b/packages/eslint-spotify/src/rules/react/no-react-fc.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Rule } from 'eslint';
+import { TSESTree } from '@typescript-eslint/types';
+import * as ESTree from 'estree';
+import { TSTypeReferenceHelper, createDocsUrl } from '../../util/helpers';
+
+/**
+ * List of TypeScript definitions we don't want to encourage related to React.FC
+ */
+const discouragedTypes = [
+  'FC',
+  'SFC',
+  'FunctionComponent',
+  'React.FC',
+  'React.SFC',
+  'React.FunctionComponent',
+];
+
+const rule: Rule.RuleModule = {
+  meta: {
+    docs: {
+      category: 'Best Practices',
+      description: 'Prevent use of React.FC and React.SFC',
+      url: createDocsUrl('react/no-react-fc.md'),
+    },
+    messages: {
+      default:
+        'Usage of React.FC and React.SFC types are discouraged when creating React components.',
+    },
+    schema: [],
+    fixable: 'code',
+    type: 'suggestion',
+  },
+  create(context: Rule.RuleContext) {
+    return {
+      TSTypeReference(node: ESTree.Node) {
+        const helper = new TSTypeReferenceHelper(
+          (node as unknown) as TSESTree.TSTypeReference,
+        );
+
+        if (!helper.hasParent()) {
+          return;
+        }
+
+        if (!helper.containsOneOfType(discouragedTypes)) {
+          return;
+        }
+
+        context.report({
+          node,
+          messageId: 'default',
+        });
+      },
+    } as Rule.RuleListener;
+  },
+};
+
+export default rule;

--- a/packages/eslint-spotify/src/util/helpers.ts
+++ b/packages/eslint-spotify/src/util/helpers.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TSESTree } from '@typescript-eslint/types';
+
+export const createDocsUrl = (pathname: string): string => {
+  return `https://github.com/spotify/web-scripts/blob/master/packages/eslint-spotify/src/rules/${pathname}`;
+};
+
+export class TSTypeReferenceHelper {
+  constructor(public node: TSESTree.TSTypeReference) {}
+
+  hasParent(): boolean {
+    return !!this.node.parent;
+  }
+
+  /**
+   * Determines whether our ESLint Node (from the AST) is cast to a specific TypeScript type
+   *
+   * @example new Node(...).containsOneOfType(["React.FC", "React.SFC"]) # => true
+   * @param types Array<string> a list of strings for the types (i.e. ["React.SFC", "React.FC"])
+   * @returns true if one of the types is set
+   */
+  public containsOneOfType(types: Array<string>): boolean {
+    // Let's check if the type definition is React.FC versus FC
+    // Examples: "FC" returns true, "React.FC" returns false
+    const { left, right } = this.node.typeName as any;
+    const isSingular: boolean = !(left && right);
+
+    // Let's get a human-readable type for our current node
+    const { name: singularName } = this.node.typeName as any;
+    const currentNodeTypeName = isSingular
+      ? singularName
+      : `${left.name}.${right.name}`;
+
+    return types.some(type => type === currentNodeTypeName);
+  }
+}

--- a/packages/eslint-spotify/src/util/testHelpers.ts
+++ b/packages/eslint-spotify/src/util/testHelpers.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RuleTester } from 'eslint';
+
+export const createRuleTester = (): RuleTester => {
+  return new RuleTester({
+    parser: require.resolve('@typescript-eslint/parser'),
+    parserOptions: {
+      ecmaVersion: 2018,
+      ecmaFeatures: {
+        experimentalObjectRestSpread: true,
+        jsx: true,
+      },
+      sourceType: 'module',
+    },
+  });
+};

--- a/packages/eslint-spotify/tsconfig.json
+++ b/packages/eslint-spotify/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@spotify/web-scripts/config/tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "types": ["node", "jest"],
+    "isolatedModules": false,
+    "noEmit": true,
+    "jsx": "preserve"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1766,6 +1766,19 @@
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
 
+"@types/eslint@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.0.tgz#eb5c5b575237334df24c53195e37b53d66478d7b"
+  integrity sha512-LpUXkr7fnmPXWGxB0ZuLEzNeTURuHPavkC5zuU4sg62/TgL5ZEjamr5Y8b6AftwHtx2bPJasI+CL0TT2JwQ7aA==
+  dependencies:
+    "@types/estree" "*"
+    "@types/json-schema" "*"
+
+"@types/estree@*":
+  version "0.0.45"
+  resolved "https://registry.npmjs.org/@types/estree/-/estree-0.0.45.tgz#e9387572998e5ecdac221950dab3e8c3b16af884"
+  integrity sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g==
+
 "@types/events@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
@@ -1821,6 +1834,11 @@
   dependencies:
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
+
+"@types/json-schema@*":
+  version "7.0.5"
+  resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
+  integrity sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==
 
 "@types/json-schema@^7.0.3":
   version "7.0.4"
@@ -1953,9 +1971,9 @@
     "@typescript-eslint/typescript-estree" "3.6.1"
     eslint-visitor-keys "^1.1.0"
 
-"@typescript-eslint/types@3.6.1":
+"@typescript-eslint/types@3.6.1", "@typescript-eslint/types@^3.6.1":
   version "3.6.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-3.6.1.tgz#87600fe79a1874235d3cc1cf5c7e1a12eea69eee"
+  resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-3.6.1.tgz#87600fe79a1874235d3cc1cf5c7e1a12eea69eee"
   integrity sha512-NPxd5yXG63gx57WDTW1rp0cF3XlNuuFFB5G+Kc48zZ+51ZnQn9yjDEsjTPQ+aWM+V+Z0I4kuTFKjKvgcT1F7xQ==
 
 "@typescript-eslint/typescript-estree@2.34.0":
@@ -9749,7 +9767,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.7.4:
+typescript@^3.7.4, typescript@^3.9.6:
   version "3.9.6"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.6.tgz#8f3e0198a34c3ae17091b35571d3afd31999365a"
   integrity sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==


### PR DESCRIPTION
Hello!

I've been working on improving my ESLint plugin knowledge. I have been particularly interested in "platformizing" the creation of ESLint plugins, especially within Spotify - and `web-scripts` seemed like potentially a great place to host this.

The main thought behind this was to introduce a `no-react-fc` rule which adheres to an ADR (architecture decision record) set by the [Backstage](https://github.com/spotify/web-scripts/blob/master/packages/eslint-spotify/src/rules/react/no-react-fc.md) team.

That being said, I am not sure if this should live here. It could even live in the Backstage repository, and then once it is a little more matured, it could be promoted to `web-scripts`. Let me know what you all think.