### PR TITLE
Implement ESLint rule for "discouraged words" in our codebases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,8 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: yarn install
       run: yarn
+    - name: yarn build
+      run: yarn build
     - name: lint
       run: yarn lint
     - name: test

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The other projects in this repo are shared configurations for common tools we us
 - [@spotify/eslint-config-base](./packages/eslint-config-base)
 - [@spotify/eslint-config-react](./packages/eslint-config-react)
 - [@spotify/eslint-config-typescript](./packages/eslint-config-typescript)
+- [@spotify/eslint-plugin](./packages/eslint-plugin)
 - [@spotify/prettier-config](./packages/prettier-config)
 - [@spotify/tsconfig](./packages/tsconfig)
 

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -54,4 +54,9 @@ module.exports = {
     sourceType: 'module',
   },
   settings,
+  plugins: ['@spotify/eslint-plugin'],
+  rules: {
+    // no discouraged words
+    '@spotify/best-practices/no-discouraged-words': 'warn',
+  },
 };

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -21,6 +21,7 @@
     "@spotify/eslint-config-base": "^8.0.0",
     "@spotify/eslint-config-react": "^8.0.2",
     "@spotify/eslint-config-typescript": "^8.0.1",
+    "@spotify/eslint-plugin": "^8.0.2",
     "@spotify/web-scripts-utils": "^8.0.0",
     "@typescript-eslint/eslint-plugin": "^3.4.0",
     "@typescript-eslint/parser": "^3.4.0",
@@ -34,6 +35,7 @@
     "eslint": "^7.3.1"
   },
   "peerDependencies": {
+    "@spotify/eslint-plugin": ">=8.x",
     "eslint": ">=7.x"
   },
   "publishConfig": {

--- a/packages/eslint-plugin/.eslintrc.json
+++ b/packages/eslint-plugin/.eslintrc.json
@@ -1,0 +1,13 @@
+{
+  "overrides": [
+    {
+      "files": [
+        "src/rules/best-practices/no-discouraged-words.{md,ts}",
+        "src/rules/best-practices/no-discouraged-words.test.ts"
+      ],
+      "rules": {
+        "@spotify/best-practices/no-discouraged-words": "off"
+      }
+    }
+  ]
+}

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -1,0 +1,31 @@
+# @spotify/eslint-plugin
+
+This contains all Spotify-specific eslint rules.
+
+## Installation
+
+```sh
+npm install --save-dev eslint @spotify/eslint-plugin
+```
+
+## Rules
+
+| Category       | Name                                    | Description                                                                          |
+| -------------- | --------------------------------------- | ------------------------------------------------------------------------------------ |
+| Best Practices | [`best-practices/no-discouraged-words`] | Prevents usage of specific words. [See more][`best-practices/no-discouraged-words`]. |
+
+[`best-practices/no-discouraged-words`]: https://github.com/spotify/web-scripts/blob/master/packages/eslint-spotify/src/rules/best-practices/no-discouraged-words.md
+
+## Usage
+
+After installing, update your project's `.eslintrc.json` config:
+
+```js
+{
+  "plugins": ["@spotify/eslint-plugin"],
+}
+```
+
+---
+
+Read the [ESlint config docs](http://eslint.org/docs/user-guide/configuring#extending-configuration-files) for more information.

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@spotify/eslint-plugin",
+  "version": "8.0.2",
+  "description": "Set of rules for Spotify's custom ESLint rules",
+  "author": "Bilawal Hameed <bil@spotify.com>",
+  "homepage": "https://github.com/spotify/web-scripts/blob/master/packages/eslint-plugin#readme",
+  "keywords": [
+    "eslint",
+    "eslint-plugin",
+    "react",
+    "typescript"
+  ],
+  "license": "Apache-2.0",
+  "main": "cjs/index.js",
+  "module": "esm/index.js",
+  "types": "types",
+  "files": [
+    "cjs",
+    "esm",
+    "types"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/spotify/web-scripts.git",
+    "directory": "packages/eslint-plugin"
+  },
+  "bugs": {
+    "url": "https://github.com/spotify/web-scripts/issues"
+  },
+  "scripts": {
+    "build": "web-scripts build",
+    "test": "web-scripts test",
+    "lint": "web-scripts lint --stylecheck",
+    "format": "web-scripts format"
+  },
+  "devDependencies": {
+    "@spotify/web-scripts": "^8.0.1",
+    "@types/eslint": "^7.2.0",
+    "@types/jest": "^26.0.0",
+    "@typescript-eslint/parser": "^3.4.0",
+    "@typescript-eslint/types": "^3.6.1",
+    "eslint": "^7.3.1",
+    "typescript": "^3.9.6"
+  },
+  "peerDependencies": {
+    "@typescript-eslint/parser": "^3.0.0",
+    "eslint": ">=7.x"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=10.18.0"
+  }
+}

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import path from 'path';
+import { Rule } from 'eslint';
+
+type RulesInput = string[];
+type RulesOutput = { [key: string]: Rule.RuleModule };
+
+const exportRules = (rulesInput: RulesInput): RulesOutput => {
+  return rulesInput.reduce(
+    (rulesOutput, rule) => ({
+      ...rulesOutput,
+      [rule]: require(`./${path.join('./rules/', rule)}`).default,
+    }),
+    {} as RulesOutput,
+  );
+};
+
+module.exports = {
+  rules: exportRules(['best-practices/no-discouraged-words']),
+};

--- a/packages/eslint-plugin/src/rules/best-practices/no-discouraged-words.md
+++ b/packages/eslint-plugin/src/rules/best-practices/no-discouraged-words.md
@@ -1,0 +1,27 @@
+# Prevents usage of discouraged words. (best-practices/no-discouraged-words)
+
+Use in order to prevent discouraged words in variable names and comments.
+
+```js
+// .eslintrc.json
+{
+  "plugins": ["@spotify/eslint-plugin"],
+  "rules": {
+    "@spotify/best-practices/no-discouraged-words": "error",
+  }
+}
+```
+
+## Discouraged words
+
+```js
+const discouragedWords = ['blacklist', 'whitelist'];
+```
+
+To make a contribution to the list, see [this file](./no-discouraged-words.ts). PRs are most welcome!
+
+## Rule details
+
+This rule will raise the following error whenever you refer to one of the discouraged words above:
+
+> Usage of the word "{word}" is strongly discouraged. Please use a different word.

--- a/packages/eslint-plugin/src/rules/best-practices/no-discouraged-words.test.ts
+++ b/packages/eslint-plugin/src/rules/best-practices/no-discouraged-words.test.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import rule from './no-discouraged-words';
+import { createRuleTester } from '../../util/testHelpers';
+
+const defaultErrorMessageWithWord = (word: string): string =>
+  `Usage of the word "${word}" is strongly discouraged. Please use a different word.`;
+
+createRuleTester().run('best-practices/no-discouraged-words', rule, {
+  valid: [
+    {
+      code: 'var foo = () => {};',
+    },
+    {
+      code: 'var foo: String = () => {};',
+    },
+    {
+      code: 'var foo: String = () => ({} as ExampleObject);',
+    },
+    {
+      // We currently don't do "advanced" checking of the discouraged words. That's something we can add over time.
+      code: 'var black_list = "";',
+    },
+    {
+      // This plugin only covers variable naming. It's unclear if there are unexpected side effects if we flat out ban the words.
+      // In the future, if we see there is not, let's check the entire codebase and avoid them.
+      code: 'var foo = "blacklist";',
+    },
+    {
+      code: "/* Hello world. I'm using no discouraged words. */",
+    },
+  ],
+  invalid: [
+    {
+      code: 'var whitelist = "";',
+      errors: [defaultErrorMessageWithWord('whitelist')],
+    },
+    {
+      code: 'var blacklist = "";',
+      errors: [defaultErrorMessageWithWord('blacklist')],
+    },
+    {
+      code: 'var foo = blacklist => "";',
+      errors: [defaultErrorMessageWithWord('blacklist')],
+    },
+    {
+      code: 'var foo = _blacklist => "";',
+      errors: [defaultErrorMessageWithWord('blacklist')],
+    },
+    {
+      code: 'var foo = (bar: Blacklist) => "";',
+      errors: [defaultErrorMessageWithWord('blacklist')],
+    },
+    {
+      code: 'var foo = bar => "" as Blacklist;',
+      errors: [defaultErrorMessageWithWord('blacklist')],
+    },
+    {
+      code: 'var bLacKLisT = "";',
+      errors: [defaultErrorMessageWithWord('blacklist')],
+    },
+    {
+      code: 'var _blacklist = "";',
+      errors: [defaultErrorMessageWithWord('blacklist')],
+    },
+    {
+      code: 'var wordsWithBlacklistAndAfter = "";',
+      errors: [defaultErrorMessageWithWord('blacklist')],
+    },
+    {
+      code: 'var { blacklist } = {};',
+      // Because this translates to '{ var blacklist: blacklist } = {}' the plugin reports the error twice
+      errors: [
+        defaultErrorMessageWithWord('blacklist'),
+        defaultErrorMessageWithWord('blacklist'),
+      ],
+    },
+    {
+      code: 'var blacklist = {}; console.log(blacklist);',
+      // Because we're using the word twice in the syntax, it'll report twice. Maybe we can clear this up later.
+      errors: [
+        defaultErrorMessageWithWord('blacklist'),
+        defaultErrorMessageWithWord('blacklist'),
+      ],
+    },
+    {
+      code: 'var { blacklist: name } = {};',
+      errors: [defaultErrorMessageWithWord('blacklist')],
+    },
+    {
+      code: 'var { name: blacklist } = {};',
+      errors: [defaultErrorMessageWithWord('blacklist')],
+    },
+    {
+      code: 'var foo: Blacklist = "";',
+      errors: [defaultErrorMessageWithWord('blacklist')],
+    },
+    {
+      code: 'var foo = "" as Blacklist;',
+      errors: [defaultErrorMessageWithWord('blacklist')],
+    },
+    {
+      code: 'var foo = "" as Example.Blacklist;',
+      errors: [defaultErrorMessageWithWord('blacklist')],
+    },
+    {
+      code: 'var foo = "" as Blacklist.Example;',
+      errors: [defaultErrorMessageWithWord('blacklist')],
+    },
+    {
+      code: 'var foo = ""; // blacklist',
+      errors: [defaultErrorMessageWithWord('blacklist')],
+    },
+    {
+      code: 'enum Blacklist {}',
+      errors: [defaultErrorMessageWithWord('blacklist')],
+    },
+    {
+      code: 'class Blacklist {}',
+      errors: [defaultErrorMessageWithWord('blacklist')],
+    },
+    {
+      code: 'type Blacklist = {}',
+      errors: [defaultErrorMessageWithWord('blacklist')],
+    },
+    {
+      code: "/* Hello world. I'm using the discouraged word blacklist. */",
+      errors: [defaultErrorMessageWithWord('blacklist')],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/rules/best-practices/no-discouraged-words.ts
+++ b/packages/eslint-plugin/src/rules/best-practices/no-discouraged-words.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Rule } from 'eslint';
+import { TSESTree } from '@typescript-eslint/types';
+import { createDocsUrl } from '../../util/helpers';
+
+/**
+ * List of discouraged words in the form of RegEx (regular expressions).
+ */
+const discouragedWords = ['blacklist', 'whitelist'];
+
+const rule: Rule.RuleModule = {
+  meta: {
+    docs: {
+      category: 'Best Practices',
+      description: 'Prevent use of discouraged words.',
+      url: createDocsUrl('best-practices/no-discouraged-words.md'),
+    },
+    schema: [],
+    fixable: 'code',
+    type: 'suggestion',
+  },
+  create(context: Rule.RuleContext) {
+    return {
+      // This checks all the JS comments for use of discouraged word. This line is an example of a comment.
+      Program(): void {
+        const comments = context.getSourceCode().getAllComments();
+        comments.forEach(comment => {
+          const commentText = comment.value;
+          const commentTextViolation = discouragedWords.find(word =>
+            commentText.match(new RegExp(word, 'i')),
+          );
+
+          if (!commentTextViolation) {
+            // There is no violation here.
+            return;
+          }
+
+          context.report({
+            // @ts-ignore
+            node: comment,
+            message: `Usage of the word "${commentTextViolation}" is strongly discouraged. Please use a different word.`,
+          });
+        });
+      },
+
+      // This checks all the JS syntax for use of discouraged words.
+      Identifier(node: TSESTree.Identifier) {
+        const variableName = node.name;
+        const variableNameViolation = discouragedWords.find(word =>
+          variableName.match(new RegExp(word, 'i')),
+        );
+
+        if (!variableNameViolation) {
+          // There is no violation here
+          return;
+        }
+
+        // Report it as an error to ESLint
+        context.report({
+          node,
+          message: `Usage of the word "${variableNameViolation}" is strongly discouraged. Please use a different word.`,
+        });
+      },
+    } as Rule.RuleListener;
+  },
+};
+
+export default rule;

--- a/packages/eslint-plugin/src/util/helpers.ts
+++ b/packages/eslint-plugin/src/util/helpers.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const createDocsUrl = (pathname: string): string => {
+  return `https://github.com/spotify/web-scripts/blob/master/packages/eslint-plugin/src/rules/${pathname}`;
+};

--- a/packages/eslint-plugin/src/util/testHelpers.ts
+++ b/packages/eslint-plugin/src/util/testHelpers.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RuleTester } from 'eslint';
+
+export const createRuleTester = (): RuleTester => {
+  return new RuleTester({
+    parser: require.resolve('@typescript-eslint/parser'),
+    parserOptions: {
+      ecmaVersion: 2018,
+      ecmaFeatures: {
+        experimentalObjectRestSpread: true,
+        jsx: true,
+      },
+      sourceType: 'module',
+    },
+  });
+};

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@spotify/web-scripts/config/tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "types": ["node", "jest"],
+    "isolatedModules": false,
+    "noEmit": true,
+    "jsx": "preserve"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1739,6 +1739,19 @@
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
 
+"@types/eslint@^7.2.0":
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.2.2.tgz#c88426b896efeb0b2732a92431ce8aa7ec0dee61"
+  integrity sha512-psWuwNXuKR2e6vMU5d2qH0Kqzrb2Zxwk+uBCF2LsyEph+Nex3lFIPMJXwxfGesdtJM2qtjKoCYsyh76K3x9wLg==
+  dependencies:
+    "@types/estree" "*"
+    "@types/json-schema" "*"
+
+"@types/estree@*":
+  version "0.0.45"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.45.tgz#e9387572998e5ecdac221950dab3e8c3b16af884"
+  integrity sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g==
+
 "@types/fs-extra@^9.0.1":
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.1.tgz#91c8fc4c51f6d5dbe44c2ca9ab09310bd00c7918"
@@ -1796,7 +1809,7 @@
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
 
-"@types/json-schema@^7.0.3":
+"@types/json-schema@*", "@types/json-schema@^7.0.3":
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
   integrity sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==
@@ -1932,7 +1945,7 @@
     "@typescript-eslint/typescript-estree" "3.10.1"
     eslint-visitor-keys "^1.1.0"
 
-"@typescript-eslint/types@3.10.1":
+"@typescript-eslint/types@3.10.1", "@typescript-eslint/types@^3.6.1":
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-3.10.1.tgz#1d7463fa7c32d8a23ab508a803ca2fe26e758727"
   integrity sha512-+3+FCUJIahE9q0lDi1WleYzjCwJs5hIsbugIgnbB+dSCYUxl8L6PwmsyOPFZde2hc1DlTo/xnkOgiTLSyAbHiQ==
@@ -9713,7 +9726,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.7.4:
+typescript@^3.7.4, typescript@^3.9.6:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==


### PR DESCRIPTION
To help support the shift towards more inclusive wording in our software, which is a simple yet impactful change for the Spotify R&D community to make, I have been investigating how to encourage such a shift in the web community. Currently, it covers two words in the community that we should phase out - blacklist and whitelist - and naturally over time this list will (and should) be expected to grow.

For this reason, I'm thinking it makes the most sense as an ESLint plugin. That's what this PR proposes.

### Why?
- ESLint is popular, and used already by the Spotify community.
- It has plenty of support across many code editors, including Visual Studio Code. This makes it easier to use during development (rather than retroactively renaming variables).
- It can be gradually rolled out across codebases when used with other tools such as [lint-changed](https://www.npmjs.com/package/lint-changed) and [husky](https://www.npmjs.com/package/husky).

### What does the ESLint rule check?

- JavaScript Comments
- JavaScript Variables, Methods, Classes, Destructuring, Imports.
- TypeScript Types, Enums, Casting.

It uses `@typescript-eslint/parser` with ESLint in order to function.

### Unanswered Questions

- **What are the guidelines for adding new words?** Given that the rule itself is pretty strict (it isn't just variable names, but pretty much a reference for the word in the entire codebase). I haven't had any time to think about this in detail, but would love some insight from the R&D community.
- **Do we want to make this opt-in for now, and then by default later?** There may be unintended side-effects that we haven't figured out yet.
- **Should this live in a separate repository?** I think it is best served here, as it caters primarily to Spotify's software. Plus, it will be published as a separate package for the open source community to use as they wish.

### Screenshot

![Screenshot 2020-07-26 at 20 06 48](https://user-images.githubusercontent.com/918552/88486337-4f81f500-cf7d-11ea-88bd-aa4a0be3e4de.png)