### PR TITLE
feat: use TypeScript 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@spotify/eslint-config-oss": "^1.0.0",
     "husky": "^4.0.0",
     "lerna": "^3.20.2",
-    "typescript": "^3.7.4"
+    "typescript": "^4.0.2"
   },
   "husky": {
     "hooks": {

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -15,10 +15,10 @@
     "test": "./run-tests.sh"
   },
   "devDependencies": {
-    "typescript": "^3.7.4"
+    "typescript": "^4.0.2"
   },
   "peerDependencies": {
-    "typescript": ">=3.2 <4"
+    "typescript": ">=4 <5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/tsconfig/tsconfig.json
+++ b/packages/tsconfig/tsconfig.json
@@ -5,6 +5,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "importHelpers": false,
+    "incremental": true,
     "isolatedModules": true,
     "module": "esnext",
     "moduleResolution": "node",

--- a/packages/web-scripts/package.json
+++ b/packages/web-scripts/package.json
@@ -53,7 +53,7 @@
     "prettier": "^2.0.5",
     "semantic-release": "^17.1.0",
     "ts-jest": "^26.3.0",
-    "typescript": "^3.7.4"
+    "typescript": "^4.0.2"
   },
   "devDependencies": {
     "@types/rimraf": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9713,10 +9713,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.7.4:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+typescript@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"
+  integrity sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==
 
 uglify-js@^3.1.4:
   version "3.10.2"


### PR DESCRIPTION
BREAKING CHANGE: must upgrade to TypeScript 4 as a consumer; new tsconfig takes advantage of
incremental + noEmit

fix #487, #252