### PR TITLE
fix: update ts-jest config

### DIFF
--- a/packages/web-scripts/config/jest.config.js
+++ b/packages/web-scripts/config/jest.config.js
@@ -22,7 +22,7 @@ module.exports = {
   preset: 'ts-jest/presets/js-with-ts',
   globals: {
     'ts-jest': {
-      tsConfig: {
+      tsconfig: {
         allowJs: true,
       },
     },


### PR DESCRIPTION
The `tsConfig` option was deprecated in [ts-jest@26.4.2](https://github.com/kulshekhar/ts-jest/blob/5a7009e9f475ae5676ca52a59039fa9549a4f4f7/CHANGELOG.md#deprecations) in favor of `tsconfig`. 

This should get rid of warnings like this,

<img width="731" alt="Skärmavbild 2021-01-02 kl  17 00 24" src="https://user-images.githubusercontent.com/16004130/103461256-43187a00-4d1d-11eb-9630-5dd66d81d409.png">
 