### PR TITLE
Disable no-undef

### DIFF
--- a/packages/eslint-config-base/es5.js
+++ b/packages/eslint-config-base/es5.js
@@ -356,7 +356,7 @@ module.exports = {
     // disallow use of undefined when initializing variables
     'no-undef-init': 0,
     // disallow use of undeclared variables unless mentioned in a /*global */ block
-    'no-undef': 2,
+    'no-undef': 0,
     // disallow use of undefined variable
     'no-undefined': 0,
     // disallow declaration of variables that are not used in the code


### PR DESCRIPTION
It is recommended to disable `no-undef` in TypeScript projects, as documented here:

[We strongly recommend that you do not use the no-undef lint rule on TypeScript projects. The checks it provides are already provided by TypeScript without the need for configuration - TypeScript just does this significantly better.](https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/FAQ.md#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors)