### PR TITLE
fix: precommit opts destructuring

### DIFF
--- a/packages/web-scripts/src/index.ts
+++ b/packages/web-scripts/src/index.ts
@@ -145,9 +145,9 @@ program
     const {
       tests,
       typecheck,
-      'jest-config': jestConfig,
-      'eslint-config': eslintConfig,
-      'prettier-config': prettierConfig,
+      jestConfig,
+      eslintConfig,
+      prettierConfig,
     } = getOpts(cmd);
     const t: PrecommitTaskDesc = {
       name: 'precommit',


### PR DESCRIPTION
The `precommit` command in web-scripts currently destructures the opts [like so](https://github.com/spotify/web-scripts/blob/b6469e5a6a84b389145576bba56adf70194f1c98/packages/web-scripts/src/index.ts#L145-L151):

```
const {
  tests,
  typecheck,
  'jest-config': jestConfig,
  'eslint-config': eslintConfig,
  'prettier-config': prettierConfig,
} = getOpts(cmd);
```

The latter three are undefined as the hyphenated names do not exist in the command opts. This PR fixes this with the following:

```
const {
  tests,
  typecheck,
  jestConfig,
  eslintConfig,
  prettierConfig,
} = getOpts(cmd);
```
