### PR TITLE
feat(husky): add support for Husky v6

### DIFF
--- a/packages/web-scripts/src/SharedTypes.ts
+++ b/packages/web-scripts/src/SharedTypes.ts
@@ -71,6 +71,7 @@ export type CommitTaskDesc = {
 export type CommitMsgTaskDesc = {
   name: 'commitmsg';
   config: string;
+  edit?: string;
 } & TaskDesc;
 
 export type ReleaseTaskDesc = {

--- a/packages/web-scripts/src/Tasks/CommitTasks.ts
+++ b/packages/web-scripts/src/Tasks/CommitTasks.ts
@@ -145,7 +145,7 @@ export function commitMsgTask(
     '--no-install',
     'commitlint',
     `--config=${task.config}`,
-    `--edit=${process.env.HUSKY_GIT_PARAMS}`,
+    `--edit=${task.edit || process.env.HUSKY_GIT_PARAMS}`,
     ...task.restOptions,
   ];
   dbg('npx args %o', args);

--- a/packages/web-scripts/src/index.ts
+++ b/packages/web-scripts/src/index.ts
@@ -229,12 +229,17 @@ program
     'path to the commitlint config.',
     COMMITLINT_CONIFG,
   )
+  .option(
+    '--edit [path]',
+    'read last commit message from the specified file (only necessary when using Husky v6).',
+  )
   .action((...args) => {
     const cmd = getCommand(args);
-    const { config } = getOpts(cmd);
+    const { config, edit } = getOpts(cmd);
     const t: CommitMsgTaskDesc = {
       name: 'commitmsg',
       config,
+      edit,
       restOptions: cmd.args,
     };
 


### PR DESCRIPTION
## 👀 What changed?

This PR adds support for using Husky v6. An additional parameter `--edit` was added in order to be able to pass along the information provided by Husky. If the `--edit` option isn't set, the fallback is `HUSKY_GIT_PARAMS`. This ensures backwards compatibility with current setups.

## 🧪 Alternative

It is possible to pass along the `--edit` parameter, as follows:

```bash
yarn web-scripts commitmsg --edit=$1
```

Here, `$1` is the variable provided by Husky, and it points to the last commit message from the specified file. Whilst this works, it isn't clear that one can add the `--edit` parameter.

## 📝 Context

When running the following command (as specified in the README file), the installed version of Husky is 6.0.0.

```bash
yarn add --dev @spotify/web-scripts husky
```

This version [removes](https://typicode.github.io/husky/#/?id=husky_git_params-ie-commitlint-) support for the `HUSK_GIT_PARAMS` environment variable, [which causes](https://github.com/spotify/web-scripts/blob/master/packages/web-scripts/src/Tasks/CommitTasks.ts#L148) `undefined` to be passed to the `--edit` option, which in turn causes a problem in `commitlint`.