### PR TITLE
ci(lerna): fix lerna publish

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -15,7 +15,7 @@ then
   echo "spotify/web-scripts: Configuring npm for publishing..."
   echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
   echo "spotify/web-scripts: Attempting publish..."
-  npx lerna publish --yes --conventional-commits --create-release=github --registry=https://registry.npmjs.org
+  npx lerna publish --yes --force-publish --conventional-commits --create-release=github --registry=https://registry.npmjs.org
   exit $?
 else
   echo "spotify/web-scripts: No release will be triggered." >&2

--- a/release.sh
+++ b/release.sh
@@ -1,3 +1,10 @@
+# This release script determines if a publish should happen using a dry run of semantic release to determine if the
+# commits contain publishable changes (feat, bug, breaking change). If so, lerna will be used to perform the actual
+# publish, however, lerna also has its own logic for determining whether to publish. Specifically, it will run git diff
+# in each package, excluding markdown files, tests, etc. So any attempt to force a version bump with an empty commit or
+# readme tweak will fail. To get around this, we pass the `force-publish` option to lerna, skipping the git diff for
+# changed packages. This allows the semantic release dry run check to be the deciding factor for publishing.
+
 # this message is logged by semantic-release when one of the commits found by web-scripts should trigger a release
 expected_release_message="The release type for the commit is"
 


### PR DESCRIPTION
The release script determines if a publish should happen using a dry run of semantic release to determine if the commits contain publishable changes (feat, bug, breaking change).

If true, the release script uses lerna to publish, however, lerna has its own logic for determining whether to publish, specifically running a git diff in each package. It will exclude markdown files, tests, etc, so an attempt to force a version bump with an empty commit or readme tweak will fail:

Example

```
$ ./release.sh
spotify/web-scripts: Running semantic-release in --dry-run to see if we should trigger a lerna release.
[4:03:31 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The release type for the commit is major
spotify/web-scripts: A release will be triggered.
spotify/web-scripts: Configuring git for Github Actions Lerna publish...
...
... trimmed
...
lerna notice cli v4.0.0
lerna info Looking for changed packages since v10.1.0
lerna info ignoring diff in paths matching [
lerna info ignoring diff in paths matching   '*.md',
lerna info ignoring diff in paths matching   '__test__/**',
lerna info ignoring diff in paths matching   '__fixtures__/**',
lerna info ignoring diff in paths matching   '**/*.test.{j|t}s',
lerna info ignoring diff in paths matching   '@(!(package)).json'
lerna info ignoring diff in paths matching ]
lerna info No changed packages found
```

This PR will pass the `force-publish` option to lerna, skipping the git diff for changed packages (https://lerna.js.org/#command-publish). This should allow semantic release to be the deciding factor for publishing.