### PR TITLE
chore(tsconfig): don't double-define the rules for strict mode

### DIFF
--- a/packages/tsconfig/tsconfig.json
+++ b/packages/tsconfig/tsconfig.json
@@ -11,19 +11,13 @@
     "moduleResolution": "node",
     "noEmit": true,
     "noFallthroughCasesInSwitch": true,
-    "noImplicitAny": true,
     "noImplicitReturns": true,
-    "noImplicitThis": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "pretty": true,
     "removeComments": true,
     "resolveJsonModule": true,
     "strict": true,
-    "strictBindCallApply": true,
-    "strictFunctionTypes": true,
-    "strictNullChecks": true,
-    "strictPropertyInitialization": true,
     "stripInternal": true
   }
 }


### PR DESCRIPTION
tsconfig `compilerOptions.strict` is an option that enables a set of other options. But those options were also independently enabled, so double defined. I personally think it's clearer to not have double defined properties, and it lets me more easily read the list of other properties you've got set.

Another alternative is to remove `compilerOptions.strict` and enable each of these options (plus the other strict mode options that weren't explicitly enabled) individually, which would be ok too.

Or you could just double define, it's not that big a deal, I can figure out which rules you've enabled anyway.

Miss y'all! 😄 