### PR TITLE
Revert "Add no-floating-promises to TS config"

### DIFF
--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -53,7 +53,5 @@ module.exports = {
     // allow functions to be defined after they're used
     'no-use-before-define': 'off',
     '@typescript-eslint/no-use-before-define': ['error', 'nofunc'],
-    // all promises must have appropriate error handling
-    '@typescript-eslint/no-floating-promises': 'warn',
   },
 };


### PR DESCRIPTION
Reverts spotify/web-scripts#907

Introducing this new rule causes ESLint to fail with the following error:

```
Error: Error while loading rule '@typescript-eslint/no-floating-promises': You have used a rule which requires parserServices to be generated. You must therefore provide a value for the "parserOptions.project" property for @typescript-eslint/parser.
```

Removing from this release so that it doesn't block