### PR TITLE
fix: do not output type declarations for cjs/esm

### DIFF
--- a/packages/web-scripts/src/Tasks/BuildTask.ts
+++ b/packages/web-scripts/src/Tasks/BuildTask.ts
@@ -69,6 +69,8 @@ async function buildCJS(task: BuildTaskDesc): Promise<string> {
   const cmd = 'npx';
   const args = [
     'tsc',
+    '--declaration',
+    'false',
     '--allowJs',
     '--outDir',
     'cjs',
@@ -86,6 +88,8 @@ async function buildESM(task: BuildTaskDesc): Promise<string> {
   const cmd = 'npx';
   const args = [
     'tsc',
+    '--declaration',
+    'false',
     '--allowJs',
     '--outDir',
     'esm',


### PR DESCRIPTION
Thanks @yuriteixeira for spotting this bug where we output declarations for directories we don't need.