### PR TITLE
build(deps): update min typescript version to 4.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@spotify/eslint-plugin": "^13.0.0",
     "husky": "^8.0.1",
     "lerna": "^5.1.8",
-    "typescript": "^4.2.3"
+    "typescript": "^4.5.0"
   },
   "resolutions": {
     "minimist": "^1.2.6",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -40,7 +40,7 @@
     "@typescript-eslint/parser": "^5.13.0",
     "@typescript-eslint/types": "^5.13.0",
     "eslint": "^8.10.0",
-    "typescript": "^4.2.3"
+    "typescript": "^4.5.0"
   },
   "peerDependencies": {
     "@typescript-eslint/parser": "^5.13.0",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -15,7 +15,7 @@
     "test": "true"
   },
   "devDependencies": {
-    "typescript": "^4.2.3"
+    "typescript": "^4.5.0"
   },
   "peerDependencies": {
     "typescript": ">=4 <5"

--- a/packages/web-scripts/package.json
+++ b/packages/web-scripts/package.json
@@ -53,7 +53,7 @@
     "prettier": "^2.2.1",
     "semantic-release": "^19.0.2",
     "ts-jest": "^28.0.5",
-    "typescript": "^4.2.3"
+    "typescript": "^4.5.0"
   },
   "devDependencies": {
     "@types/rimraf": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8580,10 +8580,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.2.3, typescript@^4.4.3, typescript@^4.6.4:
+typescript@^4.4.3, typescript@^4.6.4:
   version "4.7.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
   integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+
+typescript@^4.5.0:
+  version "4.9.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
+  integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
 
 uglify-js@^3.1.4:
   version "3.16.2"


### PR DESCRIPTION
Updated the minimum typescript version from 4.2.3 to 4.5.0 in all relevant packages.

**Context:**
The current major version of Encore Web (v6) requires Typescript v4.5.0 or higher. 

Because most encore-web customers get Typescript transitively through web-scripts, encore-web is unable to use a peerDependency to communicate to customers when their Typescript version is too old. If we were to add a `typescript: ^4.5.0` peerDep, encore-web customers getting typescript from web-scripts would see an incorrect/irrelevant "unmet peer dependency" warning that they can't rectify.

An easy solution is to bump the min TS version in web-scripts, likely followed by a fleetshift prompting encore-web customers to upgrade to the latest web-scripts. There's a [precedent for bumping web-scripts typescript versions in patches](https://github.com/spotify/web-scripts/commit/275e6819f3ce1e5e56e12bcf10f8f36e605a6ddb). See [Encore Web Typescript requirement spike]((if curious, see [spike](https://docs.google.com/document/d/1qJoiPNaowUCRu3q0gDgD1kI1GgYkZ8w8n4lCCsdof8o/edit?usp=sharing) for more info)) for more context.
